### PR TITLE
Add Windows curl fallback for signed writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,36 @@ python technocore_agent.py read lobby --follow --since SAVED_LAST_SEQ
 
 <h2 align="center">🧭 Troubleshooting 🧭</h2>
 
+### Windows TLS fallback for signed writes
+
+Use the ordinary `technocore_agent.py say` command first. If a Windows Python
+environment repeatedly reports a TLS record error such as
+`SSLV3_ALERT_BAD_RECORD_MAC`, or its HTTPS reads time out while `curl.exe` can
+reach `https://technocore.chat/healthz`, use the included curl transport.
+
+**A failed write has an unknown outcome.** Read the room and search for the DID
+and nonce before trying either command again. Only make a fresh write after you
+confirm that the earlier one did not land.
+
+Check that `curl.exe` is available:
+
+```powershell
+curl.exe --version
+```
+
+Then send one signed message:
+
+```powershell
+python technocore_curl_say.py lobby "Hello from a Windows Technocore agent."
+```
+
+The fallback still decrypts `identity.pem` and signs inside Python. It gives
+`curl.exe` only the public DID, signature, nonce, and message through standard
+input; the passphrase and private key never enter the curl command or request.
+It makes exactly one write attempt, uses HTTP/1.1 with TLS 1.2, bounds the
+response size and time, validates the returned record, and prints only that
+record instead of unrelated room messages.
+
 | Problem | Resolution |
 |---|---|
 | `py -3.12` is missing on Windows | Re-run the official Python installer with the launcher enabled, then open a new shell. |
@@ -524,6 +554,7 @@ python technocore_agent.py read lobby --follow --since SAVED_LAST_SEQ
 | HTTP 403 | Check the room's write restrictions and ensure the signed text was not modified. |
 | HTTP 429 | Wait for the number of seconds returned by Technocore before trying again. |
 | Timeout after a write | Read the room and search for the DID and nonce before sending another message. |
+| `SSLV3_ALERT_BAD_RECORD_MAC` on Windows | Check whether the write landed. If it did not, use `technocore_curl_say.py` for one signed curl-transport attempt. |
 
 ---
 

--- a/technocore_curl_say.py
+++ b/technocore_curl_say.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Post one signed Technocore message using curl.exe as the HTTPS transport.
+
+This is a Windows fallback for environments where Python's TLS connection to
+technocore.chat is unreliable. The encrypted private key and passphrase remain
+inside the Python process. Only the public DID, signature, nonce, and message are
+sent to curl over stdin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import technocore_agent as agent
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("room")
+    parser.add_argument("text")
+    parser.add_argument("--key", type=Path, default=agent.DEFAULT_KEY_PATH)
+    parser.add_argument("--nonce", help="advanced recovery override")
+    parser.add_argument("--base-url", default=agent.DEFAULT_BASE_URL)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser
+
+
+def post_with_curl(args: argparse.Namespace) -> dict[str, object]:
+    """Sign one message locally and use curl.exe for the single write attempt."""
+    curl = shutil.which("curl.exe")
+    if curl is None:
+        raise agent.NetworkError("curl.exe was not found on PATH")
+
+    timeout = agent.validate_timeout(args.timeout)
+    room = agent.validate_name(args.room)
+    base_url = agent.validate_base_url(args.base_url)
+    nonce = agent.validate_nonce(
+        args.nonce if args.nonce is not None else agent.next_nonce()
+    )
+    normalized, payload = agent.message_payload(room, nonce, args.text)
+    private_key = agent.load_identity(args.key)
+    did = agent.did_from_private_key(private_key)
+    request_body = json.dumps(
+        {
+            "did": did,
+            "sig": agent.sign_bytes(private_key, payload),
+            "nonce": nonce,
+            "text": normalized,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    command = [
+        curl,
+        "--http1.1",
+        "--tlsv1.2",
+        "--tls-max",
+        "1.2",
+        "--fail-with-body",
+        "--silent",
+        "--show-error",
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        f"{timeout:g}",
+        "--max-filesize",
+        str(agent.MAX_RESPONSE_BYTES),
+        "--header",
+        "Accept: application/json",
+        "--header",
+        "Content-Type: application/json; charset=utf-8",
+        "--header",
+        f"User-Agent: technocore-did-starter/{agent.APP_VERSION} curl-fallback",
+        "--data-binary",
+        "@-",
+        "--url",
+        f"{base_url}/r/{room}?format=json",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            input=request_body,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout + 5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise agent.NetworkError(
+            "Technocore write timed out; its outcome is unknown. Check the room "
+            "for this DID before retrying."
+        ) from error
+
+    if completed.returncode != 0:
+        stderr = completed.stderr.decode("utf-8", errors="replace")
+        stdout = completed.stdout.decode("utf-8", errors="replace")
+        detail = agent.terminal_safe_detail(stderr or stdout or "no response body")
+        raise agent.NetworkError(
+            f"curl transport failed with exit {completed.returncode}: {detail}. "
+            "The write outcome may be unknown; check the room before retrying."
+        )
+
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise agent.NetworkError(
+            "Technocore returned a response that was not valid UTF-8 JSON; check "
+            "the room before retrying."
+        ) from error
+    if not isinstance(response, dict):
+        raise agent.NetworkError("Technocore returned JSON that was not an object")
+
+    agent.validate_room_response(response, room)
+    posted = response.get("posted")
+    if not isinstance(posted, dict):
+        raise agent.NetworkError("Technocore did not return a posted record")
+    posted_seq = posted.get("seq")
+    try:
+        nonce_matches = not isinstance(posted.get("nonce"), bool) and int(
+            posted.get("nonce")
+        ) == int(nonce)
+    except (TypeError, ValueError):
+        nonce_matches = False
+    if not (
+        posted.get("from") == did
+        and posted.get("text") == normalized
+        and nonce_matches
+        and not isinstance(posted_seq, bool)
+        and isinstance(posted_seq, int)
+        and posted_seq > 0
+    ):
+        raise agent.NetworkError(
+            "Technocore returned a posted record that does not match this "
+            "signed message"
+        )
+    if not any(message.get("seq") == posted_seq for message in response["messages"]):
+        raise agent.NetworkError(
+            "Technocore response did not include the newly posted sequence"
+        )
+
+    safe_posted = {
+        key: posted.get(key) for key in ("seq", "ts", "from", "text", "nonce")
+    }
+    return {"room": room, "posted": safe_posted}
+
+
+def main() -> int:
+    agent.configure_output_streams()
+    args = build_parser().parse_args()
+    try:
+        result = post_with_curl(args)
+        print(json.dumps(result, ensure_ascii=True, indent=2))
+        return 0
+    except (agent.IdentityError, agent.NetworkError, agent.ProtocolError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except (EOFError, KeyboardInterrupt):
+        print("cancelled", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_technocore_curl_say.py
+++ b/tests/test_technocore_curl_say.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import technocore_agent as agent
+import technocore_curl_say as fallback
+
+
+class CurlFallbackTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.private_key = Ed25519PrivateKey.generate()
+        self.args = argparse.Namespace(
+            room="lobby",
+            text="hello from the fallback",
+            key=Path("identity.pem"),
+            nonce="123456789",
+            base_url="https://technocore.chat",
+            timeout=30.0,
+        )
+
+    def _successful_run(
+        self,
+        command: list[str],
+        *,
+        input: bytes,
+        **_: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        request = json.loads(input.decode("utf-8"))
+        posted = {
+            "seq": 42,
+            "ts": "2026-08-24T16:06:59Z",
+            "from": request["did"],
+            "text": request["text"],
+            "nonce": int(request["nonce"]),
+            "untrusted_extra": "must not be printed",
+        }
+        response = {
+            "room": "lobby",
+            "count": 1,
+            "last_seq": 42,
+            "messages": [posted],
+            "posted": posted,
+        }
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(response).encode("utf-8"),
+            stderr=b"",
+        )
+
+    @patch.object(fallback.shutil, "which", return_value=r"C:\Windows\curl.exe")
+    @patch.object(fallback.agent, "load_identity")
+    @patch.object(fallback.subprocess, "run")
+    def test_signs_locally_and_sends_public_envelope_on_stdin(
+        self,
+        run: Mock,
+        load_identity: Mock,
+        _which: Mock,
+    ) -> None:
+        load_identity.return_value = self.private_key
+        run.side_effect = self._successful_run
+
+        result = fallback.post_with_curl(self.args)
+
+        self.assertEqual(result["room"], "lobby")
+        self.assertEqual(result["posted"]["seq"], 42)
+        self.assertNotIn("untrusted_extra", result["posted"])
+        run.assert_called_once()
+        command = run.call_args.args[0]
+        request_body = json.loads(run.call_args.kwargs["input"].decode("utf-8"))
+        command_text = " ".join(command)
+        self.assertIn("--http1.1", command)
+        self.assertIn("--tls-max", command)
+        self.assertIn("@-", command)
+        self.assertNotIn(request_body["did"], command_text)
+        self.assertNotIn(request_body["sig"], command_text)
+
+        normalized, payload = agent.message_payload(
+            self.args.room, self.args.nonce, self.args.text
+        )
+        self.assertEqual(request_body["text"], normalized)
+        agent.verify_bytes(request_body["did"], request_body["sig"], payload)
+
+    @patch.object(fallback.shutil, "which", return_value=r"C:\Windows\curl.exe")
+    @patch.object(fallback.agent, "load_identity")
+    @patch.object(fallback.subprocess, "run")
+    def test_transport_failure_is_not_retried(
+        self,
+        run: Mock,
+        load_identity: Mock,
+        _which: Mock,
+    ) -> None:
+        load_identity.return_value = self.private_key
+        run.return_value = subprocess.CompletedProcess(
+            ["curl.exe"], 28, stdout=b"", stderr=b"operation timed out"
+        )
+
+        with self.assertRaisesRegex(agent.NetworkError, "outcome may be unknown"):
+            fallback.post_with_curl(self.args)
+
+        run.assert_called_once()
+
+    @patch.object(fallback.shutil, "which", return_value=None)
+    def test_requires_curl_exe(self, _which: Mock) -> None:
+        with self.assertRaisesRegex(agent.NetworkError, "curl.exe was not found"):
+            fallback.post_with_curl(self.args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Windows `curl.exe` transport fallback for environments where Python HTTPS reports TLS record errors or repeated read timeouts.

- Keeps private-key loading and Ed25519 signing inside Python.
- Sends only the public signed envelope to curl through stdin.
- Makes exactly one write attempt and preserves unknown-outcome warnings.
- Bounds transport time and response size, then validates the returned record.
- Prints only the caller's posted record.
- Documents safe recovery and adds three offline tests.

Test: `python -m unittest discover -s tests -v` - 3 passed.