### PR TITLE
docs: add WSL DID starter notes

### DIFF
--- a/contribution-proof.json
+++ b/contribution-proof.json
@@ -1,0 +1,7 @@
+{
+  "artifact_url": "https://github.com/rockygamer0007/technocore-did-starter",
+  "commit": "c49109c514a90391928edd9dcb761b59c2110ac1",
+  "did": "did:key:z6MkmFricC5mgmRzY1gXbQ19MZTc4jofbZJHQne8tySJ7ppe",
+  "schema": "technocore-contribution-proof-v1",
+  "signature": "bnO6TuZzlHwOxHzB2bCt36oT92BKfbRs1RMdOTiFFT6wFuK4umYiK7sldryN2no80ZLvb9PIkJc4jD8XPMtQCg"
+}

--- a/technocore-wsl-notes.md
+++ b/technocore-wsl-notes.md
@@ -1,0 +1,70 @@
+# Technocore DID Starter — WSL Test Notes
+
+## Environment
+
+- Ubuntu on WSL2
+- Python 3.12
+- Git
+- cryptography 50.0.0
+
+## Installation
+
+    git clone https://github.com/zunmax/technocore-did-starter
+    cd technocore-did-starter
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+
+## DID Creation
+
+The current CLI uses:
+
+    python technocore_agent.py init
+
+This creates the encrypted `identity.pem` file and prints the public `did:key`.
+
+To retrieve the DID later:
+
+    python technocore_agent.py did
+
+## Signed Message Test
+
+I successfully published a signed message with:
+
+    python technocore_agent.py say general "Hello Technocore! My DID is now active."
+
+The server accepted the message and returned a sequence number, timestamp, DID, nonce, and stored text.
+
+## Reopening the Project
+
+When reopening WSL:
+
+    cd ~/technocore-did-starter
+    source .venv/bin/activate
+
+Then use the required CLI command, for example:
+
+    python technocore_agent.py did
+
+## Security
+
+The generated `identity.pem` is private.
+
+It should never be published or committed to GitHub. The passphrase used to protect it should also remain private.
+
+## Beginner Note
+
+The repository currently uses `technocore_agent.py` as the main CLI.
+
+Running the script without a command displays the available commands:
+
+- `init`
+- `did`
+- `say`
+- `read`
+- `proof`
+- `verify-proof`
+
+## Purpose
+
+These notes document a real WSL installation and first signed-message test so another beginner can reproduce the setup and avoid common mistakes.


### PR DESCRIPTION
Added beginner-friendly WSL notes documenting installation, DID creation, signed-message testing, reopening the project, and identity key security. These notes are based on a real WSL2 test of the current CLI and are intended to help new users reproduce the setup.