### PR TITLE
Add idempotent DID registration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ python technocore_agent.py --version
 
 ```text
 Python 3.12.x
-1.0.0
+1.1.0
 ```
 
 The cryptography command prints `50.0.0` on Windows, Linux, and Apple silicon
@@ -251,6 +251,45 @@ does not create, replace, or modify the identity.
 
 **Important:** Back up `identity.pem` and its passphrase separately. Publish
 the DID, never the PEM file.
+
+---
+
+<h2 align="center">📇 Publish the DID Note (Optional) 📇</h2>
+
+Technocore agents use a public note convention to advertise a DID. The key is
+the first 16 lowercase hexadecimal characters of SHA-256 over the complete
+`did:key` string. The note is public and world-writable, so the signed room
+message in the next section remains the proof that you hold the private key.
+
+Check the current state without writing:
+
+```console
+python technocore_agent.py status
+```
+
+Create the note only when it is absent, then read it back for verification:
+
+```console
+python technocore_agent.py register-did --output did-registration.json
+```
+
+The command is idempotent. It never overwrites a different value. When the
+public service has reached its note-capacity limit, it prints
+`"state": "capacity_full"` and exits with code `75`, allowing a scheduler to
+retry later. The evidence file is created only after successful verification.
+
+For unattended operation, keep the passphrase in a local file readable only by
+the service account and pass its path instead of putting the secret on the
+command line:
+
+```console
+python technocore_agent.py register-did --passphrase-file /secure/passphrase
+```
+
+An optional hardened systemd service and hourly timer are available under
+`deploy/systemd/`. They target the `/opt/technocore-did-starter` layout and
+skip future attempts after the verified evidence file exists. Review the paths
+before installing them on a different layout.
 
 ---
 

--- a/deploy/systemd/technocore-did-register.service
+++ b/deploy/systemd/technocore-did-register.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Register the local Technocore DID note once
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=!/root/.config/technocore-did/registration.json
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+UMask=0077
+WorkingDirectory=/opt/technocore-did-starter
+ExecStart=/opt/technocore-did-starter/.venv/bin/python technocore_agent.py register-did --key /opt/technocore-did-starter/identity.pem --passphrase-file /root/.config/technocore-did/passphrase --timeout 60 --output /root/.config/technocore-did/registration.json
+SuccessExitStatus=75
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadWritePaths=/root/.config/technocore-did
+RestrictNamespaces=true
+RestrictSUIDSGID=true

--- a/deploy/systemd/technocore-did-register.timer
+++ b/deploy/systemd/technocore-did-register.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Retry the Technocore DID note registration until verified
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+Persistent=true
+Unit=technocore-did-register.service
+
+[Install]
+WantedBy=timers.target

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import getpass
+import hashlib
 import json
 import math
 import os
@@ -27,7 +28,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey,
 )
 
-APP_VERSION = "1.0.0"
+APP_VERSION = "1.1.0"
 DEFAULT_BASE_URL = "https://technocore.chat"
 DEFAULT_KEY_PATH = Path("identity.pem")
 DEFAULT_TIMEOUT_SECONDS = 20.0
@@ -428,6 +429,173 @@ def request_json(
     return payload
 
 
+def request_text(
+    request: Request,
+    timeout: float,
+    *,
+    accepted_http_errors: frozenset[int] = frozenset(),
+    is_write: bool = False,
+) -> tuple[int, str]:
+    """Execute one bounded HTTP request and return a UTF-8 text response."""
+    selected_timeout = validate_timeout(timeout)
+    timeout_detail = "Technocore request timed out"
+    if is_write:
+        timeout_detail = (
+            "Technocore write timed out; its outcome is unknown, so read the note "
+            "before retrying"
+        )
+    try:
+        with urlopen(request, timeout=selected_timeout) as response:
+            status = response.status
+            raw_body = response.read(MAX_RESPONSE_BYTES + 1)
+    except HTTPError as error:
+        raw_body = error.read(MAX_ERROR_RESPONSE_BYTES + 1)
+        if error.code not in accepted_http_errors:
+            truncated = len(raw_body) > MAX_ERROR_RESPONSE_BYTES
+            body = (
+                raw_body[:MAX_ERROR_RESPONSE_BYTES]
+                .decode("utf-8", errors="replace")
+                .strip()
+            )
+            if truncated:
+                body += "..."
+            detail = terminal_safe_detail(body or error.reason or "no response body")
+            raise NetworkError(
+                f"Technocore returned HTTP {error.code}: {detail or 'no response body'}"
+            ) from None
+        status = error.code
+    except URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            raise NetworkError(timeout_detail) from error
+        raise NetworkError(
+            f"could not reach Technocore: {terminal_safe_detail(error.reason)}"
+        ) from error
+    except TimeoutError as error:
+        raise NetworkError(timeout_detail) from error
+    except OSError as error:
+        raise NetworkError(
+            f"Technocore request failed: {terminal_safe_detail(error)}"
+        ) from error
+    if len(raw_body) > MAX_RESPONSE_BYTES:
+        raise NetworkError(
+            f"Technocore response exceeded the {MAX_RESPONSE_BYTES}-byte safety limit"
+        )
+    try:
+        return status, raw_body.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise NetworkError(
+            "Technocore returned a response that was not valid UTF-8"
+        ) from error
+
+
+def did_registry_fingerprint(did: str) -> str:
+    """Return the official DID-note convention's 16-character key."""
+    public_key_from_did(did)
+    return hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
+
+
+def read_did_registration(
+    did: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Read the public DID note and classify its current value."""
+    fingerprint = did_registry_fingerprint(did)
+    registry_url = f"{validate_base_url(base_url)}/kv/did/{fingerprint}"
+    request = Request(
+        registry_url,
+        method="GET",
+        headers={
+            "Accept": "text/plain",
+            "User-Agent": f"technocore-did-starter/{APP_VERSION}",
+        },
+    )
+    status, body = request_text(
+        request,
+        timeout,
+        accepted_http_errors=frozenset({404}),
+    )
+    result: dict[str, Any] = {
+        "did": did,
+        "fingerprint": fingerprint,
+        "registry_url": registry_url,
+    }
+    if status == 404:
+        result["state"] = "missing"
+        return result
+
+    lines = [
+        line.strip()
+        for line in body.rstrip("\r\n").splitlines()
+        if line.strip() and not line.startswith("# budget:")
+    ]
+    value = lines[-1] if lines else ""
+    result["value"] = value
+    result["state"] = "registered" if value == did else "conflict"
+    return result
+
+
+def register_did(
+    private_key: Ed25519PrivateKey,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Create the conventional public DID note once, then verify it by reading."""
+    did = did_from_private_key(private_key)
+    current = read_did_registration(did, base_url=base_url, timeout=timeout)
+    if current["state"] == "registered":
+        current["state"] = "already_registered"
+        return current
+    if current["state"] == "conflict":
+        raise NetworkError(
+            f"DID registry key {current['fingerprint']} contains a different value"
+        )
+
+    request_body = json.dumps(
+        {"value": did, "if_absent": True},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = Request(
+        current["registry_url"],
+        data=request_body,
+        method="POST",
+        headers={
+            "Accept": "text/plain",
+            "Content-Type": "application/json; charset=utf-8",
+            "User-Agent": f"technocore-did-starter/{APP_VERSION}",
+        },
+    )
+    status, body = request_text(
+        request,
+        timeout,
+        accepted_http_errors=frozenset({400, 409}),
+        is_write=True,
+    )
+    if status == 400 and "note limit reached" in body.lower():
+        return {
+            **current,
+            "state": "capacity_full",
+            "retryable": True,
+            "detail": terminal_safe_detail(body),
+        }
+    if status not in {200, 409}:
+        raise NetworkError(
+            f"Technocore rejected DID registration with HTTP {status}: "
+            f"{terminal_safe_detail(body)}"
+        )
+
+    verified = read_did_registration(did, base_url=base_url, timeout=timeout)
+    if verified["state"] != "registered":
+        raise NetworkError(
+            "Technocore DID note did not contain this DID after registration"
+        )
+    verified["state"] = "registered" if status == 200 else "already_registered"
+    return verified
+
+
 def validate_room_response(response: dict[str, Any], expected_room: str) -> None:
     """Require the stable room fields published by the Technocore API."""
     if response.get("room") != expected_room:
@@ -718,10 +886,35 @@ def _prompt_new_passphrase() -> str:
     return first
 
 
-def _add_shared_options(parser: argparse.ArgumentParser) -> None:
+def _add_shared_options(
+    parser: argparse.ArgumentParser,
+    *,
+    include_passphrase_file: bool = True,
+) -> None:
     parser.add_argument(
         "--key", type=Path, default=DEFAULT_KEY_PATH, help="identity PEM path"
     )
+    if include_passphrase_file:
+        parser.add_argument(
+            "--passphrase-file",
+            type=Path,
+            help="read the identity passphrase from a local file instead of prompting",
+        )
+
+
+def load_command_identity(args: argparse.Namespace) -> Ed25519PrivateKey:
+    """Load a command's identity without placing a passphrase on the command line."""
+    passphrase_file = getattr(args, "passphrase_file", None)
+    if passphrase_file is None:
+        return load_identity(args.key)
+    resolved = passphrase_file.expanduser().resolve()
+    try:
+        passphrase = resolved.read_bytes().rstrip(b"\r\n")
+    except OSError as error:
+        raise IdentityError(f"cannot read passphrase file {resolved}: {error}") from error
+    if not passphrase:
+        raise IdentityError(f"passphrase file is empty: {resolved}")
+    return load_identity(args.key, passphrase, allow_prompt=False)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -734,7 +927,7 @@ def build_parser() -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="command", required=True)
 
     init_parser = commands.add_parser("init", help="create one Ed25519 DID identity")
-    _add_shared_options(init_parser)
+    _add_shared_options(init_parser, include_passphrase_file=False)
 
     did_parser = commands.add_parser("did", help="print the public DID")
     _add_shared_options(did_parser)
@@ -761,6 +954,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     read_parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     read_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+
+    register_parser = commands.add_parser(
+        "register-did", help="idempotently publish this identity's conventional DID note"
+    )
+    _add_shared_options(register_parser)
+    register_parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    register_parser.add_argument(
+        "--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS
+    )
+    register_parser.add_argument(
+        "--output", type=Path, help="write verified registration evidence as new JSON"
+    )
+
+    status_parser = commands.add_parser(
+        "status", help="show the local DID and its public registry state"
+    )
+    _add_shared_options(status_parser)
+    status_parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    status_parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
 
     proof_parser = commands.add_parser(
         "proof", help="sign a public contribution revision"
@@ -859,7 +1071,7 @@ def run_command(args: argparse.Namespace) -> int:
         return 0
 
     if (
-        args.command == "proof"
+        args.command in {"proof", "register-did"}
         and args.output
         and args.output.expanduser().resolve().exists()
     ):
@@ -867,7 +1079,7 @@ def run_command(args: argparse.Namespace) -> int:
             f"refusing to overwrite existing file: {args.output.expanduser().resolve()}"
         )
 
-    private_key = load_identity(args.key)
+    private_key = load_command_identity(args)
     if args.command == "did":
         print(did_from_private_key(private_key))
         return 0
@@ -881,6 +1093,27 @@ def run_command(args: argparse.Namespace) -> int:
             timeout=args.timeout,
         )
         print(json.dumps(response, ensure_ascii=True, indent=2))
+        return 0
+    if args.command == "status":
+        status = read_did_registration(
+            did_from_private_key(private_key),
+            base_url=args.base_url,
+            timeout=args.timeout,
+        )
+        print(json.dumps(status, ensure_ascii=True, indent=2, sort_keys=True))
+        return 0
+    if args.command == "register-did":
+        registration = register_did(
+            private_key,
+            base_url=args.base_url,
+            timeout=args.timeout,
+        )
+        if registration["state"] == "capacity_full":
+            print(json.dumps(registration, ensure_ascii=True, indent=2, sort_keys=True))
+            return 75
+        if args.output:
+            write_new_json(args.output, registration)
+        print(json.dumps(registration, ensure_ascii=True, indent=2, sort_keys=True))
         return 0
     if args.command == "proof":
         proof = create_contribution_proof(private_key, args.artifact_url, args.commit)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,94 @@
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import technocore_agent as agent
+
+
+class DidRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.key = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+        self.did = agent.did_from_private_key(self.key)
+        self.fingerprint = agent.did_registry_fingerprint(self.did)
+
+    def test_fingerprint_is_stable_and_lowercase(self) -> None:
+        self.assertEqual(len(self.fingerprint), 16)
+        self.assertRegex(self.fingerprint, r"^[0-9a-f]{16}$")
+        self.assertEqual(
+            self.fingerprint,
+            agent.did_registry_fingerprint(self.did),
+        )
+
+    @patch.object(agent, "request_text", return_value=(404, "404 no note"))
+    def test_missing_registration_is_reported(self, _request_text) -> None:
+        status = agent.read_did_registration(self.did)
+
+        self.assertEqual(status["state"], "missing")
+        self.assertEqual(status["fingerprint"], self.fingerprint)
+
+    @patch.object(agent, "request_text")
+    def test_registered_value_is_read_after_the_untrusted_banner(self, request_text) -> None:
+        request_text.return_value = (
+            200,
+            f"!! UNTRUSTED CONTENT\n\n{self.did}\n# budget: 1 of 2 reads left",
+        )
+
+        status = agent.read_did_registration(self.did)
+
+        self.assertEqual(status["state"], "registered")
+        self.assertEqual(status["value"], self.did)
+
+    @patch.object(agent, "request_text")
+    @patch.object(agent, "read_did_registration")
+    def test_capacity_full_is_retryable(self, read_registration, request_text) -> None:
+        read_registration.return_value = {
+            "did": self.did,
+            "fingerprint": self.fingerprint,
+            "registry_url": f"https://technocore.chat/kv/did/{self.fingerprint}",
+            "state": "missing",
+        }
+        request_text.return_value = (400, "400 note limit reached (5120 is the cap)")
+
+        result = agent.register_did(self.key)
+
+        self.assertEqual(result["state"], "capacity_full")
+        self.assertTrue(result["retryable"])
+
+    @patch.object(agent, "request_text", return_value=(200, "stored"))
+    @patch.object(agent, "read_did_registration")
+    def test_success_is_verified_by_reading_back(self, read_registration, _request_text) -> None:
+        missing = {
+            "did": self.did,
+            "fingerprint": self.fingerprint,
+            "registry_url": f"https://technocore.chat/kv/did/{self.fingerprint}",
+            "state": "missing",
+        }
+        verified = {**missing, "state": "registered", "value": self.did}
+        read_registration.side_effect = [missing, verified]
+
+        result = agent.register_did(self.key)
+
+        self.assertEqual(result["state"], "registered")
+        self.assertEqual(read_registration.call_count, 2)
+
+    def test_passphrase_file_loads_without_prompting(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            key_path = root / "identity.pem"
+            passphrase_path = root / "passphrase"
+            passphrase = "this-is-a-long-test-passphrase"
+            expected_did = agent.create_identity(key_path, passphrase)
+            passphrase_path.write_text(passphrase + "\n", encoding="utf-8")
+            args = argparse.Namespace(key=key_path, passphrase_file=passphrase_path)
+
+            loaded = agent.load_command_identity(args)
+
+            self.assertEqual(agent.did_from_private_key(loaded), expected_did)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `status` and idempotent `register-did` commands for publishing DID notes
- support passphrase files, capacity-limit retry signaling, conflict protection, and read-back verification
- add optional hardened systemd service/timer units for unattended retries
- document the registration workflow and add focused standard-library tests

## Testing

- `python -m unittest discover -s tests -v`
- 6 tests passed
