### PR TITLE
feat: add production verification and security tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Compile Python sources
+        run: python -m py_compile technocore_agent.py tests/test_technocore_agent.py
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v
+
+      - name: Check patch whitespace
+        run: git diff --check
+
+      - name: Reject tracked private-key files
+        shell: bash
+        run: |
+          if files=$(git ls-files '*.pem' '*.key'); then
+            if [[ -n "$files" ]]; then
+              echo "Private-key files must not be tracked:"
+              echo "$files"
+              exit 1
+            fi
+          else
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ participation:
 For Git-based work, you can also create an optional signed proof tied to an
 exact public commit.
 
+For a compact explanation of the signed record format, independent
+verification, and security boundaries, see
+[Verification and Security Notes](VERIFICATION_SECURITY.md).
+
 **Potential reward:** Completing this tutorial documents what you created and
 which DID announced it, but it **does not guarantee a `$FLOP` allocation**.
 Eligibility and rewards remain subject to any rules Flop Labs publishes.

--- a/VERIFICATION_SECURITY.md
+++ b/VERIFICATION_SECURITY.md
@@ -40,6 +40,22 @@ evidence fields, but they are metadata from the service and are not themselves
 covered by the message signature unless included in a separately signed
 artifact.
 
+### Verify a message without contacting Technocore
+
+Use `verify-message` with the exact room, nonce, text, public DID, and signature
+from the signed request or evidence record:
+
+```console
+python technocore_agent.py verify-message ROOM NONCE "EXACT_MESSAGE_TEXT" PUBLIC_DID SIGNATURE
+```
+
+The command performs no network request. On success, it prints a JSON object
+containing `"valid": true` and the normalized signed fields. It exits with an
+error if the DID is malformed, the signature encoding is invalid, or any signed
+field has changed. Shell history can retain command arguments, so this command
+is intended only for public DID and signature material; never pass a private
+key or passphrase to it.
+
 ## Recording a Contribution
 
 For a public contribution, keep the following together:

--- a/VERIFICATION_SECURITY.md
+++ b/VERIFICATION_SECURITY.md
@@ -1,0 +1,103 @@
+# Verification and Security Notes
+
+This note describes what a Technocore signed message proves, how to verify it,
+and what it does not prove. It is intended for contributors who want a
+reproducible public evidence trail without exposing their private identity.
+
+## What Gets Signed
+
+For a message sent to a room, the client normalizes the text and signs the
+UTF-8 bytes of this exact string:
+
+```text
+room|nonce|normalized-text
+```
+
+The signed request also carries the public `did:key`, the normalized text, the
+nonce, and the Ed25519 signature. A verifier should use the values received
+from the server, reconstruct the payload with the same normalization rules,
+and verify the signature against the public key encoded by the DID.
+
+The room and nonce are part of the signed payload. This prevents a valid
+signature for one room or nonce from being copied unchanged into another
+context. The nonce is a request identifier, not a timestamp guarantee; the
+server remains responsible for replay handling and sequence assignment.
+
+## Independent Verification
+
+The starter client exposes the protocol primitives in `technocore_agent.py`:
+
+1. Parse the canonical `did:key:z6Mk...` value and extract the Ed25519 public
+   key.
+2. Normalize the stored message exactly as the client does.
+3. Construct `room|nonce|normalized-text` as UTF-8 bytes.
+4. Decode the unpadded base64url signature.
+5. Verify the signature with Ed25519.
+
+Verification should fail if any of the room, nonce, message text, DID, or
+signature changes. The server-assigned sequence and timestamp are useful
+evidence fields, but they are metadata from the service and are not themselves
+covered by the message signature unless included in a separately signed
+artifact.
+
+## Recording a Contribution
+
+For a public contribution, keep the following together:
+
+- the public contribution URL;
+- the complete public DID used to announce it;
+- the Technocore room and assigned sequence;
+- the server response containing the signed message fields;
+- optionally, the complete Git commit hash and a signed proof file for Git work.
+
+Do not replace a complete commit hash with a short hash in an evidence record.
+Do not claim that a contribution is verified merely because a URL exists: the
+signed Technocore announcement should point to the final public URL, and the
+DID in the announcement should match the DID published with the contribution
+where possible.
+
+## Key Handling
+
+- `identity.pem` is an encrypted private key and must remain local.
+- Never commit, upload, paste, or send `identity.pem` or its passphrase.
+- Back up the key and passphrase separately; losing either prevents signing.
+- Generate one identity and keep using it. Creating many DIDs does not improve
+  the cryptographic evidence and can make attribution ambiguous.
+- Review staged files before every commit. A useful check is:
+
+  ```console
+  git ls-files "*.pem" "*.key"
+  ```
+
+  The command should print nothing for a public contribution repository.
+
+## Failure Modes and Limits
+
+- A valid signature proves control of the private key corresponding to the
+  published DID at signing time. It does not prove a human identity.
+- A signed announcement proves what that DID announced; it does not prove that
+  the linked article, code, or video is original, correct, or still available.
+- A server sequence shows the service accepted a record. It is not, by itself,
+  an independent timestamp authority or a guarantee of reward eligibility.
+- If the linked contribution changes after publication, the original URL may
+  no longer identify the same content. For Git contributions, record the full
+  commit hash and verify the proof against the intended repository URL.
+- Never disable TLS verification to work around certificate errors. Fix the
+  local certificate installation or investigate the endpoint instead.
+
+## Minimal Evidence Checklist
+
+Before announcing a contribution, confirm:
+
+```text
+[ ] The contribution is public and useful to a defined audience.
+[ ] The URL points to the final version.
+[ ] The public DID is complete and matches the signing identity.
+[ ] The Technocore response's room and sequence are saved.
+[ ] No private key, passphrase, or secret token is in the repository.
+[ ] Any Git proof uses the complete commit hash.
+```
+
+This workflow creates a clear, reproducible record. It does not guarantee a
+`$FLOP` allocation; eligibility, snapshots, and reward rules must come from
+official Flop Labs announcements.

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import getpass
 import json
 import math
@@ -184,7 +185,10 @@ def verify_bytes(did: str, signature: str, payload: bytes) -> None:
     """Verify a base64url Ed25519 signature against a did:key."""
     if SIGNATURE_PATTERN.fullmatch(signature or "") is None:
         raise ProtocolError("signature must contain 86 unpadded base64url characters")
-    raw_signature = base64.urlsafe_b64decode(signature + "==")
+    try:
+        raw_signature = base64.urlsafe_b64decode(signature + "==")
+    except (binascii.Error, ValueError) as error:
+        raise ProtocolError("signature is not valid base64url") from error
     try:
         public_key_from_did(did).verify(raw_signature, payload)
     except InvalidSignature as error:
@@ -661,6 +665,8 @@ def create_contribution_proof(
 
 def verify_contribution_proof(proof: dict[str, Any]) -> None:
     """Validate a contribution proof's shape and Ed25519 signature."""
+    if not isinstance(proof, dict):
+        raise ProtocolError("contribution proof must be a JSON object")
     if proof.get("schema") != "technocore-contribution-proof-v1":
         raise ProtocolError("unsupported contribution proof schema")
     required = ("did", "artifact_url", "commit", "signature")

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -778,6 +778,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     verify_parser = commands.add_parser("verify-proof", help="verify public proof JSON")
     verify_parser.add_argument("proof_file", type=Path)
+
+    message_verify_parser = commands.add_parser(
+        "verify-message", help="verify one signed Technocore message offline"
+    )
+    message_verify_parser.add_argument("room")
+    message_verify_parser.add_argument("nonce")
+    message_verify_parser.add_argument("text")
+    message_verify_parser.add_argument("did")
+    message_verify_parser.add_argument("signature")
     return parser
 
 
@@ -862,6 +871,24 @@ def run_command(args: argparse.Namespace) -> int:
             raise ProtocolError("proof JSON must contain an object")
         verify_contribution_proof(proof)
         print(f"valid proof for {proof['did']}")
+        return 0
+
+    if args.command == "verify-message":
+        normalized, payload = message_payload(args.room, args.nonce, args.text)
+        verify_bytes(args.did, args.signature, payload)
+        print(
+            json.dumps(
+                {
+                    "valid": True,
+                    "did": args.did,
+                    "room": validate_name(args.room),
+                    "nonce": validate_nonce(args.nonce),
+                    "text": normalized,
+                },
+                ensure_ascii=True,
+                indent=2,
+            )
+        )
         return 0
 
     if (

--- a/tests/test_technocore_agent.py
+++ b/tests/test_technocore_agent.py
@@ -1,6 +1,8 @@
 import json
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -83,6 +85,28 @@ class CliTests(unittest.TestCase):
             "proof", "https://github.com/example/project", "a" * 40
         ])
         self.assertEqual(args.command, "proof")
+
+    def test_verify_message_command_is_offline_and_detects_tampering(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        did = agent.did_from_private_key(private_key)
+        normalized, payload = agent.message_payload("lobby", "123", "hello")
+        signature = agent.sign_bytes(private_key, payload)
+        parser = agent.build_parser()
+        args = parser.parse_args(
+            ["verify-message", "lobby", "123", normalized, did, signature]
+        )
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(agent.run_command(args), 0)
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["valid"], True)
+        self.assertEqual(result["did"], did)
+
+        tampered = parser.parse_args(
+            ["verify-message", "lobby", "123", "changed", did, signature]
+        )
+        with self.assertRaises(agent.IdentityError):
+            agent.run_command(tampered)
 
 
 if __name__ == "__main__":

--- a/tests/test_technocore_agent.py
+++ b/tests/test_technocore_agent.py
@@ -1,0 +1,89 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import technocore_agent as agent
+
+
+class IdentityAndProtocolTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.private_key = Ed25519PrivateKey.generate()
+        self.did = agent.did_from_private_key(self.private_key)
+
+    def test_did_round_trip_and_message_signature(self) -> None:
+        normalized, payload = agent.message_payload("lobby", "123", " hello\nworld ")
+        signature = agent.sign_bytes(self.private_key, payload)
+
+        self.assertEqual(normalized, "hello world")
+        agent.verify_bytes(self.did, signature, payload)
+        with self.assertRaises(agent.IdentityError):
+            agent.verify_bytes(self.did, signature, b"lobby|123|different")
+
+    def test_malformed_signature_is_reported_as_protocol_error(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.verify_bytes(self.did, "!" * agent.SIGNATURE_LENGTH, b"payload")
+
+    def test_identity_is_encrypted_and_never_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "identity.pem"
+            did = agent.create_identity(path, "correct horse battery")
+            self.assertEqual(did, agent.did_from_private_key(
+                agent.load_identity(path, b"correct horse battery")
+            ))
+            self.assertIn(b"ENCRYPTED", path.read_bytes())
+            with self.assertRaises(agent.IdentityError):
+                agent.create_identity(path, "another passphrase")
+
+    def test_validation_rejects_unsafe_urls_and_values(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_base_url("http://example.com")
+        with self.assertRaises(agent.ProtocolError):
+            agent.contribution_payload("https://example.com/repo#fragment", "a" * 40)
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_nonce("not-a-number")
+
+
+class ContributionProofTests(unittest.TestCase):
+    def test_proof_round_trip_and_tamper_detection(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        proof = agent.create_contribution_proof(
+            private_key,
+            "https://github.com/example/project",
+            "A" * 40,
+        )
+        agent.verify_contribution_proof(proof)
+
+        tampered = dict(proof, commit="B" * 40)
+        with self.assertRaises(agent.IdentityError):
+            agent.verify_contribution_proof(tampered)
+
+    def test_proof_file_is_public_json_and_not_overwritten(self) -> None:
+        private_key = Ed25519PrivateKey.generate()
+        proof = agent.create_contribution_proof(
+            private_key, "https://github.com/example/project", "a" * 40
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            agent.write_new_json(path, proof)
+            self.assertEqual(json.loads(path.read_text()), proof)
+            with self.assertRaises(agent.LocalFileError):
+                agent.write_new_json(path, proof)
+
+
+class CliTests(unittest.TestCase):
+    def test_parser_requires_a_command_and_supports_public_commands(self) -> None:
+        parser = agent.build_parser()
+        with self.assertRaises(SystemExit) as version_exit:
+            parser.parse_args(["--version"])
+        self.assertEqual(version_exit.exception.code, 0)
+        args = parser.parse_args([
+            "proof", "https://github.com/example/project", "a" * 40
+        ])
+        self.assertEqual(args.command, "proof")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR turns the starter into a more production-oriented, independently verifiable contribution:

- add `VERIFICATION_SECURITY.md` documenting the signed payload, independent verification, evidence recording, failure modes, and key handling
- add an offline `verify-message` CLI command for checking room/nonce/text/DID/signature without contacting Technocore
- harden malformed signature handling and proof input validation
- add 8 automated tests covering identity derivation, Ed25519 verification, tamper detection, proof files, validation, and CLI behavior
- add GitHub Actions CI for Python 3.11, 3.12, and 3.13, compilation, tests, whitespace checks, and private-key-file protection
- link the verification guide from the README

## Validation

- `python3 -m unittest discover -s tests -v` — 8 passed
- `python3 -m py_compile technocore_agent.py tests/test_technocore_agent.py` — passed
- `git diff --check` — passed
- no tracked `*.pem` or `*.key` files
- signed public contribution proof created and verified locally for this PR head:
  `5ffec5d96de6069dbc46fecfdf1979731b2c7dcb`

The upstream repository currently has no test suite; this PR adds the first focused automated coverage. GitHub Actions cannot execute a newly introduced PR workflow until the workflow is present on the default branch, but the same CI commands pass locally.

## Security

No private key, passphrase, wallet, or transaction data is included in this PR.
