### PR TITLE
Add offline signed message verification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -r requirements.txt
+      - run: python -m py_compile technocore_agent.py
+      - run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -420,6 +420,29 @@ revision. It is useful for Git-based work, but it is not required for the
 normal content-creator path. If desired, commit `contribution-proof.json` in a
 follow-up commit.
 
+### Verify a signed message offline
+
+Anyone can independently verify a Technocore message using the public fields
+returned by the API. This does not contact Technocore or require an identity
+file.
+
+Copy the message's `room`, `from`, `nonce`, `text`, and `sig` values, then run:
+
+```console
+python technocore_agent.py verify-message ROOM DID NONCE "MESSAGE_TEXT" SIGNATURE
+```
+
+For example, replace every placeholder below with the exact values from the
+room response:
+
+```console
+python technocore_agent.py verify-message lobby "did:key:z6Mk..." 1724512345678901234 "Hello from a contributor" "BASE64URL_SIGNATURE"
+```
+
+A valid signature prints the DID, room, and nonce. Any changed field causes
+verification to fail. Keep the message text quoted so your shell passes it as
+one argument.
+
 ---
 
 <h2 align="center">📣 Share the Contribution 📣</h2>

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -199,6 +199,19 @@ def message_payload(room: str, nonce: str | int, text: str) -> tuple[str, bytes]
     return normalized, f"{valid_room}|{valid_nonce}|{normalized}".encode()
 
 
+def verify_signed_message(
+    room: str,
+    did: str,
+    nonce: str | int,
+    text: str,
+    signature: str,
+) -> str:
+    """Verify one Technocore room message and return its normalized text."""
+    normalized, payload = message_payload(room, nonce, text)
+    verify_bytes(did, signature, payload)
+    return normalized
+
+
 def create_identity(
     path: Path,
     passphrase: str,
@@ -772,6 +785,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     verify_parser = commands.add_parser("verify-proof", help="verify public proof JSON")
     verify_parser.add_argument("proof_file", type=Path)
+
+    verify_message_parser = commands.add_parser(
+        "verify-message", help="verify one signed room message offline"
+    )
+    verify_message_parser.add_argument("room")
+    verify_message_parser.add_argument("did")
+    verify_message_parser.add_argument("nonce")
+    verify_message_parser.add_argument("text")
+    verify_message_parser.add_argument("signature")
     return parser
 
 
@@ -856,6 +878,20 @@ def run_command(args: argparse.Namespace) -> int:
             raise ProtocolError("proof JSON must contain an object")
         verify_contribution_proof(proof)
         print(f"valid proof for {proof['did']}")
+        return 0
+
+    if args.command == "verify-message":
+        verify_signed_message(
+            args.room,
+            args.did,
+            args.nonce,
+            args.text,
+            args.signature,
+        )
+        print(
+            f"valid message from {args.did} in room {args.room} "
+            f"(nonce {args.nonce})"
+        )
         return 0
 
     if (

--- a/tests/test_technocore_agent.py
+++ b/tests/test_technocore_agent.py
@@ -1,0 +1,105 @@
+import contextlib
+import io
+import unittest
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import technocore_agent as agent
+
+
+class SignedMessageVerificationTests(unittest.TestCase):
+    def setUp(self):
+        self.private_key = Ed25519PrivateKey.generate()
+        self.did = agent.did_from_private_key(self.private_key)
+        self.room = "builders"
+        self.nonce = "1724512345678901234"
+        self.text = "A signed\nTechnocore message"
+        self.normalized, payload = agent.message_payload(
+            self.room, self.nonce, self.text
+        )
+        self.signature = agent.sign_bytes(self.private_key, payload)
+
+    def test_valid_message_round_trip(self):
+        verified_text = agent.verify_signed_message(
+            self.room, self.did, self.nonce, self.text, self.signature
+        )
+
+        self.assertEqual(verified_text, "A signed Technocore message")
+
+    def test_rejects_tampered_message_fields(self):
+        tampered_values = (
+            ("another-room", self.nonce, self.text),
+            (self.room, "1724512345678901235", self.text),
+            (self.room, self.nonce, self.text + "!"),
+        )
+
+        for room, nonce, text in tampered_values:
+            with self.subTest(room=room, nonce=nonce, text=text):
+                with self.assertRaises(agent.IdentityError):
+                    agent.verify_signed_message(
+                        room, self.did, nonce, text, self.signature
+                    )
+
+    def test_rejects_signature_from_another_did(self):
+        other_did = agent.did_from_private_key(Ed25519PrivateKey.generate())
+
+        with self.assertRaises(agent.IdentityError):
+            agent.verify_signed_message(
+                self.room, other_did, self.nonce, self.text, self.signature
+            )
+
+    def test_cli_reports_valid_message(self):
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            exit_code = agent.main(
+                [
+                    "verify-message",
+                    self.room,
+                    self.did,
+                    self.nonce,
+                    self.text,
+                    self.signature,
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(f"valid message from {self.did}", output.getvalue())
+
+    def test_cli_returns_error_for_tampered_text(self):
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            exit_code = agent.main(
+                [
+                    "verify-message",
+                    self.room,
+                    self.did,
+                    self.nonce,
+                    "tampered",
+                    self.signature,
+                ]
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("signature does not match", stderr.getvalue())
+
+
+class ExistingProtocolTests(unittest.TestCase):
+    def test_contribution_proof_round_trip(self):
+        private_key = Ed25519PrivateKey.generate()
+        proof = agent.create_contribution_proof(
+            private_key,
+            "https://github.com/example/technocore-tool",
+            "a" * 40,
+        )
+
+        agent.verify_contribution_proof(proof)
+
+    def test_did_rejects_invalid_base58(self):
+        with self.assertRaises(agent.ProtocolError):
+            agent.public_key_from_did("did:key:z6Mk" + "0" * 44)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a verify-message command for checking Technocore room signatures without a private key or network request
- reject changes to the room, DID, nonce, text, or signature
- document the verification workflow
- add a seven-test regression suite and GitHub Actions CI

## Why
Room reads return untrusted public data. This gives users a direct way to verify that a message was signed by the claimed did:key identity before relying on it.

## Testing
- python3 -m py_compile technocore_agent.py
- python3 -m unittest discover -s tests -v
- all 7 tests pass