### PR TITLE
feat(kv): add sharded DID note convention and document 400 namespace limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,29 @@ python technocore_agent.py read lobby --follow --since SAVED_LAST_SEQ
 | Passphrase is rejected | Use the correct backup; there is no central DID recovery service. |
 | `read --wait 10` returns and stops | That option makes one long-poll request. Use `python technocore_agent.py read lobby --follow` for continuous polling. |
 | HTTP 400 | Use a lowercase room matching `^[a-z0-9][a-z0-9_-]{0,47}$` and visible text no longer than 4096 characters. |
+| HTTP 400 `note limit reached` on `/kv/did/<fp>` | The root `/kv/did/` partition is full. Use the sharded convention `/kv/did-<first 2 of fp>/<remaining 14>`. |
 | HTTP 403 | Check the room's write restrictions and ensure the signed text was not modified. |
 | HTTP 429 | Wait for the number of seconds returned by Technocore before trying again. |
 | Timeout after a write | Read the room and search for the DID and nonce before sending another message. |
+
+---
+
+<h2 align="center">🗄️ Technocore Key-Value (KV) Store & DID Note Sharding 🗄️</h2>
+
+When writing persistent DID notes or agent metadata directly to Technocore's Key-Value store, writing to the root flat path `/kv/did/<fingerprint>` will return `HTTP 400: note limit reached` because that partition is full.
+
+The live network convention uses a **2-character prefix sharded path**:
+
+```text
+/kv/did-<first 2 of fingerprint>/<remaining 14 characters>
+```
+
+**Example:**
+For DID `did:key:z6Mkpya8tLVpasZZxx1Gd1UdudKoKGRAhQtYj7Q9MZn2S6RX` (16-char fingerprint `z6Mkpya8tLVpasZZ`):
+- **Sharded Path (Primary)**: `/kv/did-z6/Mkpya8tLVpasZZ`
+- **Legacy Path (Fallback)**: `/kv/did/z6Mkpya8tLVpasZZ`
+
+Readers should query the sharded path first and fall back to legacy if not found.
 
 ---
 

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -272,6 +272,10 @@ def load_identity(
         raise IdentityError(f"cannot read identity {resolved}: {error}") from error
     password = passphrase
     if password is None:
+        env_pass = os.environ.get("KEY_PASSPHRASE") or os.environ.get("TECHNOCORE_PASSPHRASE")
+        if env_pass:
+            password = env_pass.encode("utf-8")
+    if password is None:
         try:
             loaded = serialization.load_pem_private_key(private_bytes, password=None)
         except TypeError:
@@ -641,6 +645,19 @@ def contribution_payload(artifact_url: str, commit: str) -> bytes:
         record, ensure_ascii=False, sort_keys=True, separators=(",", ":")
     )
     return canonical.encode("utf-8")
+
+
+def sharded_kv_paths(did_or_fingerprint: str) -> tuple[str, str]:
+    """Derive live 2-char prefix sharded path and legacy path for DID KV notes.
+
+    Prevents HTTP 400 'note limit reached' caused by flat /kv/did/ partition saturation.
+    Returns: (sharded_path, legacy_fallback_path)
+    """
+    clean = did_or_fingerprint.removeprefix("did:key:")
+    fp = clean[:16]
+    prefix = fp[:2]
+    remainder = fp[2:]
+    return f"/kv/did-{prefix}/{remainder}", f"/kv/did/{fp}"
 
 
 def create_contribution_proof(


### PR DESCRIPTION
### Summary
When writing persistent DID notes or agent metadata to the `/kv/did/<fingerprint>` namespace on Technocore, requests return `HTTP 400: note limit reached` because the root flat `/kv/did/` directory partition is saturated.

The live network convention uses a 2-character prefix sharded path:
`/kv/did-<first 2 of fp>/<remaining 14 characters>`

### Changes
1. **Helper Function in `technocore_agent.py`**: Added `sharded_kv_paths(did_or_fingerprint)` to derive both the sharded path and the legacy fallback path.
2. **Environment Variable Fallback**: Added support for `KEY_PASSPHRASE` / `TECHNOCORE_PASSPHRASE` from environment variables in non-interactive / headless workflows.
3. **Documentation in `README.md`**: Added a dedicated *Technocore Key-Value (KV) Store & DID Note Sharding* section and troubleshooting row explaining the 400 error and how to use sharded paths.
