### PR TITLE
Warn when identity.pem has overly permissive file permissions

### DIFF
--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import re
+import stat
 import sys
 import time
 import unicodedata
@@ -266,6 +267,16 @@ def load_identity(
 ) -> Ed25519PrivateKey:
     """Load an Ed25519 identity, prompting only when an encrypted key requires it."""
     resolved = path.expanduser().resolve()
+    try:
+        mode = resolved.stat().st_mode
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            sys.stderr.write(
+                "warning: " + str(resolved) + " is readable or writable by "
+                "group/other (mode " + oct(mode & 0o777) + "); consider "
+                "running: chmod 600 " + str(resolved) + "\n"
+            )
+    except OSError:
+        pass
     try:
         private_bytes = resolved.read_bytes()
     except OSError as error:

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -268,13 +268,22 @@ def load_identity(
     """Load an Ed25519 identity, prompting only when an encrypted key requires it."""
     resolved = path.expanduser().resolve()
     try:
-        mode = resolved.stat().st_mode
-        if mode & (stat.S_IRWXG | stat.S_IRWXO):
-            sys.stderr.write(
-                "warning: " + str(resolved) + " is readable or writable by "
-                "group/other (mode " + oct(mode & 0o777) + "); consider "
-                "running: chmod 600 " + str(resolved) + "\n"
-            )
+        # POSIX mode bits are only meaningful on POSIX filesystems. Windows
+        # (os.name == "nt") synthesizes S_IRWXG/S_IRWXO from its own ACL in a
+        # way that does not reflect real group/other access, so this check
+        # would false-positive on every normal Windows identity file and
+        # recommend chmod, which does not apply there. A Windows-specific
+        # ACL-aware check would need to inspect the file's DACL instead --
+        # not implemented here, so this simply skips the check on Windows
+        # rather than warn incorrectly.
+        if os.name != "nt":
+            mode = resolved.stat().st_mode
+            if mode & (stat.S_IRWXG | stat.S_IRWXO):
+                sys.stderr.write(
+                    "warning: " + str(resolved) + " is readable or writable by "
+                    "group/other (mode " + oct(mode & 0o777) + "); consider "
+                    "running: chmod 600 " + str(resolved) + "\n"
+                )
     except OSError:
         pass
     try:

--- a/test_technocore_agent.py
+++ b/test_technocore_agent.py
@@ -1,0 +1,83 @@
+"""Regression test for the identity.pem permission warning (PR #15).
+
+Standard-library unittest only, matching this starter repo's minimal
+dependency footprint -- no pytest in requirements.txt.
+"""
+import io
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from technocore_agent import load_identity
+
+
+def _make_key_file(mode: int) -> Path:
+    """Write a syntactically-loadable dummy key file with the given mode.
+
+    load_identity's permission check runs before the key bytes are parsed,
+    so the file content only needs to exist -- it does not need to be a
+    real Ed25519 key for this test, since we only assert on the warning
+    written to stderr, not on successful key parsing.
+    """
+    fd, path_str = tempfile.mkstemp(suffix=".pem")
+    os.close(fd)
+    path = Path(path_str)
+    path.write_bytes(b"not a real key, only used for permission-check tests")
+    path.chmod(mode)
+    return path
+
+
+class TestIdentityPermissionWarning(unittest.TestCase):
+    def _load_and_capture_stderr(self, path: Path) -> str:
+        captured = io.StringIO()
+        with patch("sys.stderr", captured):
+            try:
+                load_identity(path)
+            except Exception:
+                # load_identity will fail past the permission check since
+                # the file is not a real key -- that is expected and fine,
+                # the permission-warning branch runs and writes to stderr
+                # before the real parse failure occurs.
+                pass
+        return captured.getvalue()
+
+    def test_warns_on_posix_when_group_other_readable(self):
+        path = _make_key_file(0o644)
+        try:
+            with patch("os.name", "posix"):
+                stderr_output = self._load_and_capture_stderr(path)
+            self.assertIn("group/other", stderr_output)
+            self.assertIn("chmod 600", stderr_output)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_silent_on_posix_when_owner_only(self):
+        path = _make_key_file(0o600)
+        try:
+            with patch("os.name", "posix"):
+                stderr_output = self._load_and_capture_stderr(path)
+            self.assertNotIn("group/other", stderr_output)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_silent_on_windows_regardless_of_mode(self):
+        # Windows synthesizes POSIX-style mode bits from its own ACL, and a
+        # normal Windows file commonly reports as 0o666 -- which would
+        # false-positive under a POSIX-style check. This asserts the
+        # Windows branch is skipped entirely, matching the real-world
+        # os.name == "nt", S_IMODE == 0o666 case reported against PR #15.
+        path = _make_key_file(0o666)
+        try:
+            with patch("os.name", "nt"):
+                stderr_output = self._load_and_capture_stderr(path)
+            self.assertNotIn("group/other", stderr_output)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does
Warns when identity.pem has group/other-readable or writable permissions when loaded, rather than only enforcing safe permissions at creation time.

## Why
create_identity() already sets 0o600 on the key file when it's first generated. But load_identity() never checks permissions on an existing file — so a key that gets copied, synced via cloud storage, or restored from a backup can end up with looser permissions (e.g. 0644) without any warning, silently exposing the encrypted private key to other users on a shared system.

## Behavior
Non-blocking warning to stderr, printed once per load, showing the actual mode and a suggested fix (`chmod 600 <path>`). Does not fail the load — some filesystems (WSL /mnt mounts, some network drives) don't support real POSIX permission enforcement, and a hard failure there would break legitimate use for those users.

## Tested
Verified the warning fires correctly for a 644-permission identity file and stays silent for a correctly-permissioned 600 file, with loading succeeding in both cases.