### PR TITLE
Clarify fallback when Python 3.12 isn't installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ py -3.12 -m venv .venv
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 ```
+> **If `py -3.12` fails with "No suitable Python runtime found":** you don't have Python 3.12 installed. Use `python -m venv .venv` instead of the line above — any Python 3.11+ works fine for this tool.
 
 **Only if PowerShell blocks `Activate.ps1`:** allow it for the current
 PowerShell process and retry activation:
@@ -122,6 +123,7 @@ py -3.12 -m venv .venv
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 ```
+> **If `py -3.12` fails with "No suitable Python runtime found":** you don't have Python 3.12 installed. Use `python -m venv .venv` instead of the line above — any Python 3.11+ works fine for this tool.
 
 ---
 


### PR DESCRIPTION
Ran into "No suitable Python runtime found" when only Python 3.13 was installed (py -3.12 launcher lookup fails if 3.12 specifically isn't present). Added a one-line note after both the PowerShell and Command Prompt venv-creation blocks clarifying that `python -m venv .venv` works as a fallback, so newcomers on 3.11+/3.13+ aren't stuck at the first step.