### PR TITLE
test: harden client input boundaries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v
+      - name: Compile source
+        run: python -m py_compile technocore_agent.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,14 @@ __pycache__/
 .ruff_cache/
 .pytest_cache/
 
-# Technocore identity
+# Technocore identity and local credentials
 *.pem
 *.key
+*.env
+.env.*
+!.env.example
+*.p12
+*.pfx
 
 # Local editor files
 .idea/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ exact public commit.
 which DID announced it, but it **does not guarantee a `$FLOP` allocation**.
 Eligibility and rewards remain subject to any rules Flop Labs publishes.
 
+Read the [Security Policy](SECURITY.md) before creating an identity or sending a
+message. It covers local key handling, public-message boundaries, safe network
+configuration, and vulnerability reporting.
+
 **Choose one installation section:** Follow only the Windows PowerShell,
 Windows Command Prompt, macOS, or Linux section that matches your system. After
 installing, skip the other operating systems and continue at **Verify the
@@ -198,7 +202,13 @@ PowerShell, Command Prompt, macOS Terminal, and Linux terminals:
 python --version
 python -c "import cryptography; print(cryptography.__version__)"
 python technocore_agent.py --version
+python -m unittest discover -s tests -v
+python -m py_compile technocore_agent.py
 ```
+
+The last two commands are local, network-free checks. They do not create or read
+an identity and do not send anything to Technocore. Run them from the repository
+root after installing `requirements.txt`.
 
 **Expected Python and tool versions:**
 
@@ -343,7 +353,9 @@ design source. Do not create a GitHub repository merely to archive an ordinary
 X post or video.
 
 **1. Open a terminal in the contribution folder.** This must be the folder that
-contains the work you want to publish.
+contains the work you want to publish. Use that folder for Git commands; the
+`proof` command itself belongs to this starter repository and is run in the
+starter repository root (or with an absolute path to `technocore_agent.py`).
 
 **2. Check whether Git is already initialized.** Run:
 
@@ -383,7 +395,7 @@ of `origin` in the push command below.
 ```console
 git status --short
 git diff
-git add .
+git add path/to/reviewed-file-1 path/to/reviewed-file-2
 git diff --cached --name-only
 git ls-files "*.pem" "*.key"
 git commit -m "Publish useful Technocore contribution"
@@ -391,11 +403,20 @@ git push -u origin HEAD
 git rev-parse HEAD
 ```
 
-Review the staged filenames printed by `git diff --cached --name-only`.
-**The `git ls-files` command should print nothing.** If it prints a private
-key, **stop and remove that key from Git tracking before committing.** The
-final command prints the complete revision hash used for the contribution
-proof.
+Review the staged filenames and full patch before committing:
+
+```console
+git diff --cached --name-only
+git diff --cached
+```
+
+Do not use `git add .` without reviewing the result. In addition to the
+`*.pem` and `*.key` check, look for `.env` files, cloud credentials, tokens,
+certificates, database dumps, and private URLs. The `git ls-files` command
+should print nothing. If it prints a private key or another secret, **stop and
+remove it from Git tracking before committing**; `.gitignore` cannot repair a
+secret that is already tracked. The final command prints the complete revision
+hash used for the contribution proof.
 
 Copy the complete hash printed by `git rev-parse HEAD`. Before running the next
 command:
@@ -404,10 +425,18 @@ command:
 - Keep the shown GitHub URL only if you are contributing to this repository.
   Otherwise, replace it with the public URL of your own Git repository.
 
+From the starter repository root, run the proof command with the key that
+belongs to this DID (use an absolute path when your contribution has a separate
+working directory):
+
 ```console
-python technocore_agent.py proof https://github.com/zunmax/technocore-did-starter FULL_COMMIT_HASH --output contribution-proof.json
+cd path/to/technocore-did-starter
+python technocore_agent.py proof --key identity.pem PUBLIC_GIT_REPOSITORY_URL FULL_COMMIT_HASH --output contribution-proof.json
 python technocore_agent.py verify-proof contribution-proof.json
 ```
+
+Replace `PUBLIC_GIT_REPOSITORY_URL` with the exact public repository URL and
+`FULL_COMMIT_HASH` with the complete commit hash before running either command.
 
 Expected verification result:
 
@@ -419,6 +448,17 @@ The `proof` command creates an optional signed record for a specific Git
 revision. It is useful for Git-based work, but it is not required for the
 normal content-creator path. If desired, commit `contribution-proof.json` in a
 follow-up commit.
+
+**Input and network boundaries:** The CLI validates room names, message length,
+DID/signature encodings, timeout values, and HTTPS URLs before making a request.
+The default URL is HTTPS; plain HTTP is accepted only for explicit loopback test
+servers. Base URLs and contribution artifact URLs reject empty hosts, embedded
+credentials, invalid ports, query/fragment components, paths where they are not
+allowed, and whitespace, control, or invisible characters. HTTP redirects are
+not followed, including redirects that would change scheme or host. A response
+or proof file is read only up to its configured byte limit and must be valid
+UTF-8 JSON. A write timeout has an unknown outcome: do not blindly retry; read
+the room and check the DID and nonce first.
 
 ---
 
@@ -522,7 +562,7 @@ python technocore_agent.py read lobby --follow --since SAVED_LAST_SEQ
 | `read --wait 10` returns and stops | That option makes one long-poll request. Use `python technocore_agent.py read lobby --follow` for continuous polling. |
 | HTTP 400 | Use a lowercase room matching `^[a-z0-9][a-z0-9_-]{0,47}$` and visible text no longer than 4096 characters. |
 | HTTP 403 | Check the room's write restrictions and ensure the signed text was not modified. |
-| HTTP 429 | Wait for the number of seconds returned by Technocore before trying again. |
+| HTTP 429 | Read the error details and any `Retry-After` value returned by Technocore, then wait before trying again; the CLI does not retry automatically. |
 | Timeout after a write | Read the room and search for the DID and nonce before sending another message. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ exact public commit.
 which DID announced it, but it **does not guarantee a `$FLOP` allocation**.
 Eligibility and rewards remain subject to any rules Flop Labs publishes.
 
-Read the [Security Policy](SECURITY.md) before creating an identity or sending a
+Read the proposed [Security Policy](https://github.com/zunmax/technocore-did-starter/pull/12) before creating an identity or sending a
 message. It covers local key handling, public-message boundaries, safe network
-configuration, and vulnerability reporting.
+configuration, and vulnerability reporting. It will become `SECURITY.md` on the
+default branch when PR #12 is merged.
 
 **Choose one installation section:** Follow only the Windows PowerShell,
 Windows Command Prompt, macOS, or Linux section that matches your system. After
@@ -533,8 +534,9 @@ the sequence cursor:
 python technocore_agent.py read lobby --follow
 ```
 
-The first line is the current room snapshot. After that, each non-empty response
-is printed as one JSON line. Every long-poll request automatically receives a
+When `--follow` is used without `--since`, the first line is the current room
+snapshot. With `--since`, the command starts at the supplied cursor and prints
+only later non-empty responses. Every long-poll request automatically receives a
 new cache-busting counter, and the command keeps running until you press
 `Ctrl+C`.
 

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import getpass
+import ipaddress
 import json
 import math
 import os
@@ -14,11 +16,12 @@ import sys
 import time
 import unicodedata
 from collections.abc import Callable, Iterator
+from http.client import InvalidURL
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urlsplit
-from urllib.request import Request, urlopen
+from urllib.parse import unquote, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
@@ -36,6 +39,7 @@ MIN_FOLLOW_INTERVAL_SECONDS = 0.5
 MAX_MESSAGE_CHARS = 4096
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 MAX_ERROR_RESPONSE_BYTES = 16 * 1024
+MAX_PROOF_BYTES = 256 * 1024
 MULTICODEC_ED25519 = b"\xed\x01"
 MULTIBASE_LENGTH = 48
 SIGNATURE_LENGTH = 86
@@ -65,6 +69,35 @@ class NetworkError(RuntimeError):
 
 class LocalFileError(RuntimeError):
     """A local public artifact could not be read or written safely."""
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Disable urllib's automatic redirect handling for every request."""
+
+    def redirect_request(
+        self,
+        request: Request,
+        file_object: Any,
+        code: int,
+        message: str,
+        headers: Any,
+        new_url: str,
+    ) -> None:
+        return None
+
+
+_NO_REDIRECT_OPENER = build_opener(_NoRedirectHandler)
+
+
+def urlopen(
+    request: Request,
+    data: bytes | None = None,
+    timeout: Any = None,
+) -> Any:
+    """Open a request without allowing urllib to follow redirects."""
+    if data is None:
+        return _NO_REDIRECT_OPENER.open(request, timeout=timeout)
+    return _NO_REDIRECT_OPENER.open(request, data=data, timeout=timeout)
 
 
 def base58btc_encode(data: bytes) -> str:
@@ -165,6 +198,20 @@ def validate_nonce(value: str | int) -> str:
     return nonce
 
 
+def _posted_nonce_matches(posted_nonce: Any, selected_nonce: str) -> bool:
+    """Accept only the canonical decimal representation of the nonce we sent."""
+    if isinstance(posted_nonce, bool):
+        return False
+    if isinstance(posted_nonce, int):
+        return str(posted_nonce) == selected_nonce
+    if isinstance(posted_nonce, str):
+        return (
+            posted_nonce == selected_nonce
+            and (posted_nonce == "0" or not posted_nonce.startswith("0"))
+        )
+    return False
+
+
 def next_nonce() -> str:
     """Create a high-resolution wall-clock nonce within the 19-digit limit."""
     return validate_nonce(time.time_ns())
@@ -181,10 +228,23 @@ def sign_bytes(private_key: Ed25519PrivateKey, payload: bytes) -> str:
 
 
 def verify_bytes(did: str, signature: str, payload: bytes) -> None:
-    """Verify a base64url Ed25519 signature against a did:key."""
-    if SIGNATURE_PATTERN.fullmatch(signature or "") is None:
+    """Verify a canonical base64url Ed25519 signature against a did:key."""
+    if (
+        not isinstance(signature, str)
+        or SIGNATURE_PATTERN.fullmatch(signature) is None
+    ):
         raise ProtocolError("signature must contain 86 unpadded base64url characters")
-    raw_signature = base64.urlsafe_b64decode(signature + "==")
+    try:
+        raw_signature = base64.b64decode(
+            signature + "==", altchars=b"-_", validate=True
+        )
+        canonical_signature = (
+            base64.urlsafe_b64encode(raw_signature).decode("ascii").rstrip("=")
+        )
+    except (binascii.Error, UnicodeError, ValueError) as error:
+        raise ProtocolError("signature is not valid base64url") from error
+    if canonical_signature != signature:
+        raise ProtocolError("signature must use canonical base64url encoding")
     try:
         public_key_from_did(did).verify(raw_signature, payload)
     except InvalidSignature as error:
@@ -314,40 +374,124 @@ def _load_pem_key(private_bytes: bytes, password: bytes) -> Any:
         ) from error
 
 
+def _reject_unsafe_url_text(value: str, label: str) -> None:
+    """Reject URL text that clients may interpret inconsistently."""
+    for index, character in enumerate(value):
+        if character == "%" and (
+            index + 2 >= len(value)
+            or re.fullmatch(r"[0-9A-Fa-f]{2}", value[index + 1 : index + 3]) is None
+        ):
+            raise ProtocolError(f"{label} contains an invalid percent escape")
+    for component in (value, unquote(value)):
+        for character in component:
+            if (
+                character.isspace()
+                or not character.isprintable()
+                or unicodedata.category(character) in INVISIBLE_CATEGORIES
+            ):
+                raise ProtocolError(
+                    f"{label} must not contain whitespace or invisible characters"
+                )
+
+
+def _validate_url(
+    value: str,
+    *,
+    label: str,
+    allow_loopback_http: bool = False,
+    allow_query: bool = False,
+    allow_path: bool = True,
+) -> Any:
+    """Parse and validate a URL before handing it to urllib/http.client."""
+    if not isinstance(value, str) or not value:
+        raise ProtocolError(f"{label} must be a non-empty URL")
+    if value != value.strip():
+        raise ProtocolError(f"{label} must not contain surrounding whitespace")
+    _reject_unsafe_url_text(value, label)
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+    except ValueError as error:
+        raise ProtocolError(f"{label} is malformed") from error
+    scheme = parsed.scheme.lower()
+    if not scheme or not parsed.netloc or not hostname:
+        raise ProtocolError(f"{label} must contain a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ProtocolError(f"{label} must not contain embedded credentials")
+    if not allow_query and "?" in value:
+        raise ProtocolError(f"{label} must not contain a query")
+    if "#" in value:
+        raise ProtocolError(f"{label} must not contain a fragment")
+    if not allow_path and parsed.path not in {"", "/"}:
+        raise ProtocolError(f"{label} must not contain a path")
+    if "\\" in parsed.netloc or "\\" in parsed.path:
+        raise ProtocolError(f"{label} contains an invalid path or host")
+
+    authority = parsed.netloc
+    if ":" in hostname:
+        if not authority.startswith("[") or "]" not in authority:
+            raise ProtocolError(f"{label} contains an invalid host")
+        closing_bracket = authority.find("]")
+        if closing_bracket != authority.rfind("]"):
+            raise ProtocolError(f"{label} contains an invalid host")
+        suffix = authority[closing_bracket + 1 :]
+        if suffix and not suffix.startswith(":"):
+            raise ProtocolError(f"{label} contains an invalid host")
+    elif any(character in authority for character in "[]"):
+        raise ProtocolError(f"{label} contains an invalid host")
+    if authority.endswith(":"):
+        raise ProtocolError(f"{label} contains an invalid port")
+    try:
+        _ = parsed.port
+    except ValueError as error:
+        raise ProtocolError(f"{label} contains an invalid port") from error
+    try:
+        if ":" in hostname:
+            if "%" in hostname:
+                raise ValueError("IPv6 zone identifiers are not allowed")
+            ipaddress.IPv6Address(hostname)
+        else:
+            ascii_hostname = hostname.encode("idna").decode("ascii")
+            if len(ascii_hostname) > 253 or any(
+                not label_part
+                or len(label_part) > 63
+                or label_part.startswith("-")
+                or label_part.endswith("-")
+                or not re.fullmatch(r"[A-Za-z0-9-]+", label_part)
+                for label_part in ascii_hostname.split(".")
+            ):
+                raise ValueError("invalid hostname")
+    except (UnicodeError, ValueError) as error:
+        raise ProtocolError(f"{label} contains an invalid host") from error
+
+    if scheme != "https":
+        loopback = hostname.lower() in {"localhost", "127.0.0.1", "::1"}
+        if not (allow_loopback_http and scheme == "http" and loopback):
+            raise ProtocolError(
+                f"{label} must use HTTPS, except for an explicit loopback test server"
+            )
+    return parsed
+
+
 def validate_base_url(base_url: str) -> str:
     """Require HTTPS except for explicit loopback development servers."""
-    if not isinstance(base_url, str) or not base_url or base_url != base_url.strip():
-        raise ProtocolError(
-            "base URL must be a non-empty URL without surrounding whitespace"
-        )
-    normalized = base_url.rstrip("/")
-    try:
-        parsed = urlsplit(normalized)
-    except ValueError as error:
-        raise ProtocolError("base URL is malformed") from error
-    loopback = parsed.hostname in {"localhost", "127.0.0.1", "::1"}
-    if parsed.scheme != "https" and not (parsed.scheme == "http" and loopback):
-        raise ProtocolError(
-            "base URL must use HTTPS, except for a loopback test server"
-        )
-    if not parsed.netloc or parsed.query or parsed.fragment:
-        raise ProtocolError("base URL must contain a host and no query or fragment")
-    if parsed.username is not None or parsed.password is not None:
-        raise ProtocolError("base URL must not contain embedded credentials")
-    if parsed.path not in {"", "/"}:
-        raise ProtocolError("base URL must not contain a path")
-    try:
-        _port = parsed.port
-    except ValueError as error:
-        raise ProtocolError("base URL contains an invalid port") from error
-    return normalized
+    _validate_url(
+        base_url,
+        label="base URL",
+        allow_loopback_http=True,
+        allow_path=False,
+    )
+    return base_url.rstrip("/")
 
 
 def validate_timeout(timeout: float) -> float:
     """Return a finite, positive HTTP timeout."""
     if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
         raise ProtocolError("timeout must be a finite number greater than zero")
-    selected = float(timeout)
+    try:
+        selected = float(timeout)
+    except (OverflowError, ValueError) as error:
+        raise ProtocolError("timeout must be a finite number greater than zero") from error
     if not math.isfinite(selected) or selected <= 0:
         raise ProtocolError("timeout must be a finite number greater than zero")
     return selected
@@ -355,16 +499,21 @@ def validate_timeout(timeout: float) -> float:
 
 def validate_follow_wait(wait: float) -> float:
     """Return a valid positive Technocore long-poll interval."""
-    if (
-        isinstance(wait, bool)
-        or not isinstance(wait, (int, float))
-        or not math.isfinite(float(wait))
-        or not 0 < wait <= 10
-    ):
+    if isinstance(wait, bool) or not isinstance(wait, (int, float)):
         raise ProtocolError(
             "follow wait must be greater than zero and at most 10 seconds"
         )
-    return float(wait)
+    try:
+        selected = float(wait)
+    except (OverflowError, ValueError) as error:
+        raise ProtocolError(
+            "follow wait must be greater than zero and at most 10 seconds"
+        ) from error
+    if not math.isfinite(selected) or not 0 < selected <= 10:
+        raise ProtocolError(
+            "follow wait must be greater than zero and at most 10 seconds"
+        )
+    return selected
 
 
 def request_json(
@@ -384,6 +533,8 @@ def request_json(
     try:
         with urlopen(request, timeout=selected_timeout) as response:
             raw_body = response.read(MAX_RESPONSE_BYTES + 1)
+    except InvalidURL as error:
+        raise NetworkError("Technocore request URL was invalid") from error
     except HTTPError as error:
         raw_error = error.read(MAX_ERROR_RESPONSE_BYTES + 1)
         truncated = len(raw_error) > MAX_ERROR_RESPONSE_BYTES
@@ -421,7 +572,7 @@ def request_json(
         ) from error
     try:
         payload = json.loads(body)
-    except json.JSONDecodeError as error:
+    except (json.JSONDecodeError, ValueError, UnicodeError, RecursionError) as error:
         raise NetworkError("Technocore returned a non-JSON response") from error
     if not isinstance(payload, dict):
         raise NetworkError("Technocore returned JSON that was not an object")
@@ -487,12 +638,7 @@ def post_signed_message(
             "Technocore accepted the request without returning a posted record"
         )
     posted_nonce = posted.get("nonce")
-    try:
-        matching_nonce = not isinstance(posted_nonce, bool) and int(
-            posted_nonce
-        ) == int(selected_nonce)
-    except (TypeError, ValueError):
-        matching_nonce = False
+    matching_nonce = _posted_nonce_matches(posted_nonce, selected_nonce)
     posted_seq = posted.get("seq")
     matching_record = (
         posted.get("from") == did
@@ -540,14 +686,15 @@ def read_room(
     if wait is not None:
         if since is None:
             raise ProtocolError("wait requires a since cursor")
-        if (
-            isinstance(wait, bool)
-            or not isinstance(wait, (int, float))
-            or not math.isfinite(float(wait))
-            or not 0 <= wait <= 10
-        ):
+        if isinstance(wait, bool) or not isinstance(wait, (int, float)):
             raise ProtocolError("wait must be between 0 and 10 seconds")
-        if validate_timeout(timeout) <= float(wait):
+        try:
+            selected_wait = float(wait)
+        except (OverflowError, ValueError) as error:
+            raise ProtocolError("wait must be between 0 and 10 seconds") from error
+        if not math.isfinite(selected_wait) or not 0 <= selected_wait <= 10:
+            raise ProtocolError("wait must be between 0 and 10 seconds")
+        if validate_timeout(timeout) <= selected_wait:
             raise ProtocolError("timeout must be greater than wait for long polling")
     query: dict[str, str | int | float] = {"format": "json", "limit": limit}
     if since is not None:
@@ -595,14 +742,20 @@ def follow_room(
             timeout=timeout,
         )
         cache_buster += 1
+        next_cursor = response["last_seq"]
+        if next_cursor < cursor:
+            raise NetworkError("Technocore moved the room cursor backwards")
         if response["messages"]:
-            next_cursor = response["last_seq"]
             if next_cursor <= cursor:
                 raise NetworkError(
                     "Technocore returned messages without advancing last_seq"
                 )
             cursor = next_cursor
             yield response
+        elif next_cursor > cursor:
+            # A deployment may advance its cursor while returning no retained rows.
+            # Keep following from that cursor instead of replaying an empty window.
+            cursor = next_cursor
         elapsed = time.monotonic() - request_started
         if elapsed < MIN_FOLLOW_INTERVAL_SECONDS:
             time.sleep(MIN_FOLLOW_INTERVAL_SECONDS - elapsed)
@@ -612,22 +765,13 @@ def contribution_payload(artifact_url: str, commit: str) -> bytes:
     """Build a deterministic payload linking a DID to one published revision."""
     if not isinstance(artifact_url, str) or not isinstance(commit, str):
         raise ProtocolError("artifact URL and commit must be strings")
-    if artifact_url != artifact_url.strip():
-        raise ProtocolError("artifact URL must not contain surrounding whitespace")
-    try:
-        parsed = urlsplit(artifact_url)
-    except ValueError as error:
-        raise ProtocolError("artifact URL is malformed") from error
-    if parsed.scheme != "https" or not parsed.netloc or parsed.fragment:
-        raise ProtocolError(
-            "artifact URL must be an absolute HTTPS URL without a fragment"
-        )
-    if parsed.username is not None or parsed.password is not None:
-        raise ProtocolError("artifact URL must not contain embedded credentials")
-    try:
-        _port = parsed.port
-    except ValueError as error:
-        raise ProtocolError("artifact URL contains an invalid port") from error
+    _validate_url(
+        artifact_url,
+        label="artifact URL",
+        allow_loopback_http=False,
+        allow_query=False,
+        allow_path=True,
+    )
     if COMMIT_PATTERN.fullmatch(commit) is None:
         raise ProtocolError(
             "commit must be a complete 40- or 64-character hexadecimal revision"
@@ -661,6 +805,8 @@ def create_contribution_proof(
 
 def verify_contribution_proof(proof: dict[str, Any]) -> None:
     """Validate a contribution proof's shape and Ed25519 signature."""
+    if not isinstance(proof, dict):
+        raise ProtocolError("contribution proof must contain an object")
     if proof.get("schema") != "technocore-contribution-proof-v1":
         raise ProtocolError("unsupported contribution proof schema")
     required = ("did", "artifact_url", "commit", "signature")
@@ -849,8 +995,18 @@ def run_command(args: argparse.Namespace) -> int:
     if args.command == "verify-proof":
         proof_path = args.proof_file.expanduser().resolve()
         try:
-            proof = json.loads(proof_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as error:
+            with proof_path.open("rb") as proof_file:
+                proof_bytes = proof_file.read(MAX_PROOF_BYTES + 1)
+        except (OSError, UnicodeError, ValueError, RecursionError) as error:
+            raise LocalFileError(f"cannot read proof JSON: {error}") from error
+        if len(proof_bytes) > MAX_PROOF_BYTES:
+            raise LocalFileError(
+                f"proof JSON exceeded the {MAX_PROOF_BYTES}-byte safety limit"
+            )
+        try:
+            proof_text = proof_bytes.decode("utf-8")
+            proof = json.loads(proof_text)
+        except (UnicodeError, ValueError, RecursionError) as error:
             raise LocalFileError(f"cannot read proof JSON: {error}") from error
         if not isinstance(proof, dict):
             raise ProtocolError("proof JSON must contain an object")

--- a/technocore_agent.py
+++ b/technocore_agent.py
@@ -16,7 +16,7 @@ import sys
 import time
 import unicodedata
 from collections.abc import Callable, Iterator
-from http.client import InvalidURL
+from http.client import HTTPException, InvalidURL
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -71,8 +71,41 @@ class LocalFileError(RuntimeError):
     """A local public artifact could not be read or written safely."""
 
 
+def _resolve_path(path: Path, error_type: type[Exception], label: str) -> Path:
+    """Resolve a user path without leaking symlink or filesystem exceptions."""
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError) as error:
+        raise error_type(f"cannot resolve {label} path {path}: {error}") from error
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject non-standard JSON constants such as NaN and Infinity."""
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
+def _is_loopback_hostname(hostname: str) -> bool:
+    """Return whether a hostname denotes localhost or a loopback address."""
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Disable urllib's automatic redirect handling for every request."""
+
+    def _reject_redirect(
+        self,
+        request: Request,
+        file_object: Any,
+        code: int,
+        message: str,
+        headers: Any,
+    ) -> None:
+        raise HTTPError(request.full_url, code, message, headers, file_object)
 
     def redirect_request(
         self,
@@ -84,6 +117,14 @@ class _NoRedirectHandler(HTTPRedirectHandler):
         new_url: str,
     ) -> None:
         return None
+
+    def http_error_301(self, request, fp, code, msg, headers):
+        self._reject_redirect(request, fp, code, msg, headers)
+
+    http_error_302 = http_error_301
+    http_error_303 = http_error_301
+    http_error_307 = http_error_301
+    http_error_308 = http_error_301
 
 
 _NO_REDIRECT_OPENER = build_opener(_NoRedirectHandler)
@@ -193,8 +234,10 @@ def validate_name(value: str, label: str = "room") -> str:
 def validate_nonce(value: str | int) -> str:
     """Return a nonce string accepted by the signed-write protocol."""
     nonce = str(value)
-    if NONCE_PATTERN.fullmatch(nonce) is None:
-        raise ProtocolError("nonce must contain 1-19 ASCII digits")
+    if NONCE_PATTERN.fullmatch(nonce) is None or (
+        len(nonce) > 1 and nonce.startswith("0")
+    ):
+        raise ProtocolError("nonce must contain 1-19 canonical decimal digits")
     return nonce
 
 
@@ -264,7 +307,7 @@ def create_identity(
     passphrase: str,
 ) -> str:
     """Create one encrypted private key without overwriting an existing identity."""
-    path = path.expanduser().resolve()
+    path = _resolve_path(path, IdentityError, "identity")
     if path.exists():
         raise IdentityError(f"refusing to overwrite existing identity: {path}")
     if not isinstance(passphrase, str) or len(passphrase) < 12:
@@ -325,7 +368,7 @@ def load_identity(
     password_prompt: Callable[[str], str] = getpass.getpass,
 ) -> Ed25519PrivateKey:
     """Load an Ed25519 identity, prompting only when an encrypted key requires it."""
-    resolved = path.expanduser().resolve()
+    resolved = _resolve_path(path, IdentityError, "identity")
     try:
         private_bytes = resolved.read_bytes()
     except OSError as error:
@@ -395,6 +438,7 @@ def _reject_unsafe_url_text(value: str, label: str) -> None:
 
 
 def _validate_url(
+
     value: str,
     *,
     label: str,
@@ -465,7 +509,7 @@ def _validate_url(
         raise ProtocolError(f"{label} contains an invalid host") from error
 
     if scheme != "https":
-        loopback = hostname.lower() in {"localhost", "127.0.0.1", "::1"}
+        loopback = _is_loopback_hostname(hostname)
         if not (allow_loopback_http and scheme == "http" and loopback):
             raise ProtocolError(
                 f"{label} must use HTTPS, except for an explicit loopback test server"
@@ -536,7 +580,12 @@ def request_json(
     except InvalidURL as error:
         raise NetworkError("Technocore request URL was invalid") from error
     except HTTPError as error:
-        raw_error = error.read(MAX_ERROR_RESPONSE_BYTES + 1)
+        try:
+            raw_error = error.read(MAX_ERROR_RESPONSE_BYTES + 1)
+        except (HTTPException, OSError, ValueError) as read_error:
+            raise NetworkError(
+                f"Technocore returned HTTP {error.code}; error response could not be read"
+            ) from read_error
         truncated = len(raw_error) > MAX_ERROR_RESPONSE_BYTES
         body = (
             raw_error[:MAX_ERROR_RESPONSE_BYTES]
@@ -556,6 +605,12 @@ def request_json(
         ) from error
     except TimeoutError as error:
         raise NetworkError(timeout_detail) from error
+    except HTTPException as error:
+        raise NetworkError(
+            f"Technocore response stream failed: {terminal_safe_detail(error)}"
+        ) from error
+    except ValueError as error:
+        raise NetworkError("Technocore request URL was invalid") from error
     except OSError as error:
         raise NetworkError(
             f"Technocore request failed: {terminal_safe_detail(error)}"
@@ -571,7 +626,7 @@ def request_json(
             "Technocore returned a response that was not valid UTF-8"
         ) from error
     try:
-        payload = json.loads(body)
+        payload = json.loads(body, parse_constant=_reject_json_constant)
     except (json.JSONDecodeError, ValueError, UnicodeError, RecursionError) as error:
         raise NetworkError("Technocore returned a non-JSON response") from error
     if not isinstance(payload, dict):
@@ -818,7 +873,7 @@ def verify_contribution_proof(proof: dict[str, Any]) -> None:
 
 def write_new_json(path: Path, payload: dict[str, Any]) -> None:
     """Write public proof JSON without overwriting an existing file."""
-    resolved = path.expanduser().resolve()
+    resolved = _resolve_path(path, LocalFileError, "output")
     serialized = (
         json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     )
@@ -935,12 +990,11 @@ def configure_output_streams() -> None:
 def run_command(args: argparse.Namespace) -> int:
     """Execute one parsed command and return a process exit code."""
     if args.command == "init":
-        if args.key.expanduser().resolve().exists():
-            raise IdentityError(
-                f"refusing to overwrite existing identity: {args.key.expanduser().resolve()}"
-            )
+        key_path = _resolve_path(args.key, IdentityError, "identity")
+        if key_path.exists():
+            raise IdentityError(f"refusing to overwrite existing identity: {key_path}")
         passphrase = _prompt_new_passphrase()
-        did = create_identity(args.key, passphrase)
+        did = create_identity(key_path, passphrase)
         print(did)
         return 0
 
@@ -993,7 +1047,7 @@ def run_command(args: argparse.Namespace) -> int:
         return 0
 
     if args.command == "verify-proof":
-        proof_path = args.proof_file.expanduser().resolve()
+        proof_path = _resolve_path(args.proof_file, LocalFileError, "proof")
         try:
             with proof_path.open("rb") as proof_file:
                 proof_bytes = proof_file.read(MAX_PROOF_BYTES + 1)
@@ -1005,7 +1059,7 @@ def run_command(args: argparse.Namespace) -> int:
             )
         try:
             proof_text = proof_bytes.decode("utf-8")
-            proof = json.loads(proof_text)
+            proof = json.loads(proof_text, parse_constant=_reject_json_constant)
         except (UnicodeError, ValueError, RecursionError) as error:
             raise LocalFileError(f"cannot read proof JSON: {error}") from error
         if not isinstance(proof, dict):
@@ -1017,11 +1071,10 @@ def run_command(args: argparse.Namespace) -> int:
     if (
         args.command == "proof"
         and args.output
-        and args.output.expanduser().resolve().exists()
     ):
-        raise LocalFileError(
-            f"refusing to overwrite existing file: {args.output.expanduser().resolve()}"
-        )
+        output_path = _resolve_path(args.output, LocalFileError, "proof output")
+        if output_path.exists():
+            raise LocalFileError(f"refusing to overwrite existing file: {output_path}")
 
     private_key = load_identity(args.key)
     if args.command == "did":
@@ -1041,8 +1094,8 @@ def run_command(args: argparse.Namespace) -> int:
     if args.command == "proof":
         proof = create_contribution_proof(private_key, args.artifact_url, args.commit)
         if args.output:
-            write_new_json(args.output, proof)
-            print(args.output.expanduser().resolve())
+            write_new_json(output_path, proof)
+            print(output_path)
         else:
             print(json.dumps(proof, ensure_ascii=True, indent=2, sort_keys=True))
         return 0

--- a/tests/test_technocore_agent.py
+++ b/tests/test_technocore_agent.py
@@ -5,6 +5,7 @@ import json
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.client import IncompleteRead
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import call, patch
@@ -29,8 +30,37 @@ class _Response:
         return self.body if limit < 0 else self.body[:limit]
 
 
-class _RedirectHandler(BaseHTTPRequestHandler):
+class _BrokenResponse(_Response):
+    def read(self, limit: int = -1) -> bytes:
+        raise IncompleteRead(b"partial")
+
+
+class _BrokenErrorResponse(HTTPError):
+    def read(self, limit: int = -1) -> bytes:
+        raise IncompleteRead(b"partial")
+
+
+class _MalformedRedirectHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
+        self.send_response(302)
+        self.send_header("Location", "http://[::1")
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+class _RedirectHandler(BaseHTTPRequestHandler):
+    target_hits = 0
+
+    def do_GET(self) -> None:
+        if self.path == "/target":
+            type(self).target_hits += 1
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b"{}")
+            return
         self.send_response(302)
         self.send_header("Location", "/target")
         self.end_headers()
@@ -104,6 +134,14 @@ class URLAndInputBoundaryTests(unittest.TestCase):
             agent.validate_base_url("http://127.0.0.1:8080/"),
             "http://127.0.0.1:8080",
         )
+        self.assertEqual(
+            agent.validate_base_url("http://[0:0:0:0:0:0:0:1]:8080/"),
+            "http://[0:0:0:0:0:0:0:1]:8080",
+        )
+
+    def test_noncanonical_nonce_is_rejected_before_signing(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_nonce("0123")
 
     def test_empty_host_is_rejected_for_base_and_artifact_urls(self) -> None:
         for value in ("https://", "https:///path"):
@@ -162,7 +200,23 @@ class URLAndInputBoundaryTests(unittest.TestCase):
 
 class NetworkBoundaryTests(unittest.TestCase):
     def test_redirect_is_not_followed(self) -> None:
+        _RedirectHandler.target_hits = 0
         server = ThreadingHTTPServer(("127.0.0.1", 0), _RedirectHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            request = Request(f"http://127.0.0.1:{server.server_port}/start")
+            with self.assertRaises(agent.NetworkError) as context:
+                agent.request_json(request, 2)
+            self.assertIn("HTTP 302", str(context.exception))
+            self.assertEqual(_RedirectHandler.target_hits, 0)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_malformed_redirect_is_network_error(self) -> None:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _MalformedRedirectHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         try:
@@ -196,8 +250,38 @@ class NetworkBoundaryTests(unittest.TestCase):
 
     def test_huge_json_number_is_network_error(self) -> None:
         request = Request("https://example.com")
-        huge_number = ("{\\\"value\\\":" + ("9" * 10000) + "}").encode()
+        huge_number = ('{"value":' + ("9" * 10000) + '}').encode()
         with patch.object(agent, "urlopen", return_value=_Response(huge_number)):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_broken_response_stream_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        with patch.object(agent, "urlopen", return_value=_BrokenResponse(b"partial")):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_broken_http_error_body_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        error = _BrokenErrorResponse(
+            request.full_url,
+            502,
+            "bad gateway",
+            {},
+            None,
+        )
+        with patch.object(agent, "urlopen", side_effect=error):
+            with self.assertRaises(agent.NetworkError) as context:
+                agent.request_json(request, 2)
+        self.assertIn("error response could not be read", str(context.exception))
+
+    def test_nonstandard_json_constant_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        with patch.object(
+            agent,
+            "urlopen",
+            return_value=_Response(b'{"value":NaN}'),
+        ):
             with self.assertRaises(agent.NetworkError):
                 agent.request_json(request, 2)
 
@@ -261,6 +345,13 @@ class ProofFileTests(unittest.TestCase):
         with TemporaryDirectory() as directory:
             path = Path(directory) / "proof.json"
             path.write_text('{"value":' + "9" * 10000 + "}", encoding="utf-8")
+            with self.assertRaises(agent.LocalFileError):
+                self._verify_path(path)
+
+    def test_proof_file_nonstandard_json_constant_is_local_file_error(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            path.write_text('{"value":NaN}', encoding="utf-8")
             with self.assertRaises(agent.LocalFileError):
                 self._verify_path(path)
 

--- a/tests/test_technocore_agent.py
+++ b/tests/test_technocore_agent.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import call, patch
+
+import technocore_agent as agent
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from urllib.error import HTTPError
+from urllib.request import Request
+
+
+class _Response:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, limit: int = -1) -> bytes:
+        return self.body if limit < 0 else self.body[:limit]
+
+
+class _RedirectHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(302)
+        self.send_header("Location", "/target")
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+class SignatureAndIdentityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.private_key = Ed25519PrivateKey.generate()
+        self.did = agent.did_from_private_key(self.private_key)
+        self.payload = b"lobby|123|hello"
+        self.signature = agent.sign_bytes(self.private_key, self.payload)
+
+    def test_did_and_signature_round_trip(self) -> None:
+        self.assertEqual(len(self.did), 8 + agent.MULTIBASE_LENGTH)
+        self.assertTrue(self.did.startswith("did:key:z6Mk"))
+        agent.verify_bytes(self.did, self.signature, self.payload)
+
+    def test_signature_padding_is_rejected(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.verify_bytes(self.did, self.signature + "=", self.payload)
+
+    def test_signature_trailing_bit_alias_is_rejected(self) -> None:
+        alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        last_index = alphabet.index(self.signature[-1])
+        # The final base64url character carries only two signature bits; change one
+        # of its four unused low bits while preserving those significant bits.
+        alias_index = (last_index & 0b110000) | ((last_index + 1) & 0b001111)
+        self.assertNotEqual(alias_index, last_index)
+        alias = self.signature[:-1] + alphabet[alias_index]
+        self.assertEqual(
+            base64.urlsafe_b64decode(alias + "=="),
+            base64.urlsafe_b64decode(self.signature + "=="),
+        )
+        with self.assertRaises(agent.ProtocolError):
+            agent.verify_bytes(self.did, alias, self.payload)
+
+    def test_non_string_signature_is_rejected(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.verify_bytes(self.did, None, self.payload)  # type: ignore[arg-type]
+
+    def test_encrypted_identity_round_trip_and_no_overwrite(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "test-identity.pem"
+            passphrase = "a test passphrase 123"
+            created_did = agent.create_identity(path, passphrase)
+            loaded = agent.load_identity(
+                path,
+                passphrase.encode("utf-8"),
+                allow_prompt=False,
+            )
+            self.assertEqual(created_did, agent.did_from_private_key(loaded))
+            with self.assertRaises(agent.IdentityError):
+                agent.create_identity(path, passphrase)
+            with self.assertRaises(agent.IdentityError):
+                agent.load_identity(
+                    path,
+                    b"the wrong passphrase",
+                    allow_prompt=False,
+                )
+
+
+class URLAndInputBoundaryTests(unittest.TestCase):
+    def test_base_url_valid_and_loopback_http_allowed(self) -> None:
+        self.assertEqual(
+            agent.validate_base_url("https://example.com/"), "https://example.com"
+        )
+        self.assertEqual(
+            agent.validate_base_url("http://127.0.0.1:8080/"),
+            "http://127.0.0.1:8080",
+        )
+
+    def test_empty_host_is_rejected_for_base_and_artifact_urls(self) -> None:
+        for value in ("https://", "https:///path"):
+            with self.subTest(value=value):
+                with self.assertRaises(agent.ProtocolError):
+                    agent.validate_base_url(value)
+                with self.assertRaises(agent.ProtocolError):
+                    agent.contribution_payload(value, "a" * 40)
+
+    def test_url_controls_whitespace_credentials_and_query_are_rejected(self) -> None:
+        invalid_base_urls = (
+            "https://example.com/\nnext",
+            "https://example.com/%00",
+            "https:// example.com",
+            "https://user:pass@example.com",
+            "https://example.com:bad",
+            "https://example.com:99999",
+            "https://example.com?format=json",
+            "https://example.com#fragment",
+            "https://example.com/path",
+        )
+        for value in invalid_base_urls:
+            with self.subTest(value=value):
+                with self.assertRaises(agent.ProtocolError):
+                    agent.validate_base_url(value)
+
+        invalid_artifacts = (
+            "https://user@example.com/path",
+            "https://example.com/path?x=1",
+            "https://example.com/path#part",
+            "https://example.com/path\u200b",
+            "https://example.com:bad/path",
+        )
+        for value in invalid_artifacts:
+            with self.subTest(value=value):
+                with self.assertRaises(agent.ProtocolError):
+                    agent.contribution_payload(value, "a" * 40)
+
+    def test_non_loopback_http_is_rejected(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_base_url("http://example.com")
+        with self.assertRaises(agent.ProtocolError):
+            agent.contribution_payload("http://127.0.0.1/path", "a" * 40)
+
+    def test_giant_timeout_and_wait_are_protocol_errors(self) -> None:
+        giant = 10**10000
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_timeout(giant)
+        with self.assertRaises(agent.ProtocolError):
+            agent.validate_follow_wait(giant)
+
+    def test_non_dict_proof_is_rejected(self) -> None:
+        with self.assertRaises(agent.ProtocolError):
+            agent.verify_contribution_proof([])  # type: ignore[arg-type]
+
+
+class NetworkBoundaryTests(unittest.TestCase):
+    def test_redirect_is_not_followed(self) -> None:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _RedirectHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            request = Request(f"http://127.0.0.1:{server.server_port}/start")
+            with self.assertRaises(agent.NetworkError) as context:
+                agent.request_json(request, 2)
+            self.assertIn("HTTP 302", str(context.exception))
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_bad_json_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        with patch.object(agent, "urlopen", return_value=_Response(b"not json")):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_bad_utf8_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        with patch.object(agent, "urlopen", return_value=_Response(b"\xff")):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_deep_json_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        deep_json = ("[" * 2000) + ("]" * 2000)
+        with patch.object(agent, "urlopen", return_value=_Response(deep_json.encode())):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_huge_json_number_is_network_error(self) -> None:
+        request = Request("https://example.com")
+        huge_number = ("{\\\"value\\\":" + ("9" * 10000) + "}").encode()
+        with patch.object(agent, "urlopen", return_value=_Response(huge_number)):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+    def test_large_response_is_bounded(self) -> None:
+        request = Request("https://example.com")
+        body = b"{" + (b"x" * agent.MAX_RESPONSE_BYTES) + b"}"
+        with patch.object(agent, "urlopen", return_value=_Response(body)):
+            with self.assertRaises(agent.NetworkError):
+                agent.request_json(request, 2)
+
+
+class FollowCursorTests(unittest.TestCase):
+    def test_empty_response_with_advanced_cursor_is_not_replayed(self) -> None:
+        responses = [
+            {"messages": [], "last_seq": 2},
+            {"messages": [{"seq": 3}], "last_seq": 3},
+        ]
+        with patch.object(agent, "read_room", side_effect=responses) as read_room:
+            with patch.object(agent.time, "monotonic", return_value=1.0), patch.object(agent.time, "sleep"):
+                response = next(
+                    agent.follow_room(
+                        "lobby",
+                        since=1,
+                        wait=1,
+                        base_url="http://127.0.0.1:1",
+                    )
+                )
+        self.assertEqual(response["last_seq"], 3)
+        self.assertEqual(
+            [call.kwargs["since"] for call in read_room.call_args_list], [1, 2]
+        )
+
+
+class ProofFileTests(unittest.TestCase):
+    def _verify_path(self, path: Path) -> int:
+        args = agent.build_parser().parse_args(["verify-proof", str(path)])
+        return agent.run_command(args)
+
+    def test_proof_file_size_is_bounded(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            path.write_bytes(b"{" + b" " * agent.MAX_PROOF_BYTES + b"}")
+            with self.assertRaises(agent.LocalFileError):
+                self._verify_path(path)
+
+    def test_proof_file_bad_utf8_is_local_file_error(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            path.write_bytes(b"\xff")
+            with self.assertRaises(agent.LocalFileError):
+                self._verify_path(path)
+
+    def test_proof_file_deep_json_is_local_file_error(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            path.write_bytes(("[" * 2000 + "]" * 2000).encode())
+            with self.assertRaises(agent.LocalFileError):
+                self._verify_path(path)
+
+    def test_proof_file_huge_number_is_local_file_error(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "proof.json"
+            path.write_text('{"value":' + "9" * 10000 + "}", encoding="utf-8")
+            with self.assertRaises(agent.LocalFileError):
+                self._verify_path(path)
+
+
+class PostedNonceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.private_key = Ed25519PrivateKey.generate()
+        self.did = agent.did_from_private_key(self.private_key)
+        self.selected_nonce = "123"
+        self.room = "lobby"
+        self.text = "hello"
+
+    def _response(self, posted_nonce: object) -> dict[str, object]:
+        return {
+            "room": self.room,
+            "count": 1,
+            "last_seq": 7,
+            "messages": [{"seq": 7}],
+            "posted": {
+                "from": self.did,
+                "text": self.text,
+                "nonce": posted_nonce,
+                "seq": 7,
+            },
+        }
+
+    def _post_with_nonce(self, posted_nonce: object) -> None:
+        with patch.object(agent, "request_json", return_value=self._response(posted_nonce)):
+            agent.post_signed_message(
+                self.private_key,
+                self.room,
+                self.text,
+                nonce=self.selected_nonce,
+                base_url="http://127.0.0.1:1",
+            )
+
+    def test_integer_nonce_success_path_is_preserved(self) -> None:
+        self._post_with_nonce(123)
+
+    def test_fractional_nonce_is_rejected(self) -> None:
+        with self.assertRaises(agent.NetworkError):
+            self._post_with_nonce(123.0)
+
+    def test_leading_zero_nonce_is_rejected(self) -> None:
+        with self.assertRaises(agent.NetworkError):
+            self._post_with_nonce("0123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject non-canonical Ed25519 signature encodings, malformed endpoints, unsafe redirects, and non-canonical posted nonces
- convert hostile, oversized, non-standard, or truncated JSON/proof responses into bounded CLI errors
- handle malformed redirect locations, broken response streams, and filesystem symlink loops without tracebacks
- add 31 network-free unittest regressions covering identity, cursor, URL, signature, JSON, proof, nonce, redirect, and response boundaries
- document local testing, staged-secret review, proof working-directory usage, retry boundaries, and the pending security-policy PR
- add a Python 3.12 GitHub Actions smoke workflow

## Validation

- `python -m unittest discover -s tests -v` (31 passed)
- `python -m py_compile technocore_agent.py`
- `git diff --check`
- `git ls-files '*.pem' '*.key' '*.env' '*.p12' '*.pfx'` produced no output
- no live Technocore writes; `identity.pem` was not included
